### PR TITLE
デザイン修正2

### DIFF
--- a/app/front/assets/scss/admin.scss
+++ b/app/front/assets/scss/admin.scss
@@ -81,7 +81,7 @@
               justify-content: center;
 
               &.check-icon {
-                color: rgb(59, 167, 59);
+                color: #3ba73b;
               }
             }
           }

--- a/app/front/assets/scss/common.scss
+++ b/app/front/assets/scss/common.scss
@@ -120,3 +120,13 @@ span.key-span {
     overflow-x: scroll;
   }
 }
+
+@mixin scrollbar-hidden {
+  overflow-y: scroll;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}

--- a/app/front/assets/scss/home/home.scss
+++ b/app/front/assets/scss/home/home.scss
@@ -34,6 +34,10 @@
       margin: 0 auto;
       @include home-button-text;
       display: inline-flex;
+
+      & > .icon {
+        margin-right: 0.25rem;
+      }
     }
   }
   &__event {

--- a/app/front/assets/scss/home/home.scss
+++ b/app/front/assets/scss/home/home.scss
@@ -159,6 +159,7 @@
               $color: #f07b7b,
               $border: "solid"
             );
+            color: #f07b7b;
 
             &:disabled {
               visibility: hidden;
@@ -179,11 +180,12 @@
       &--button,
       &--collective-button {
         @include home-button-text($admin-primary, false);
-        margin-right: 0.5rem;
-        .material-icons {
-          font-size: 0.9rem;
-        }
         @include text-size("normal");
+        margin-right: 0.5rem;
+
+        & > .icon {
+          margin-right: 0.25rem;
+        }
       }
     }
   }

--- a/app/front/assets/scss/home/home.scss
+++ b/app/front/assets/scss/home/home.scss
@@ -209,9 +209,6 @@
   &__footer {
     align-self: flex-end;
   }
-  &__hide-button {
-    @include home-button-text;
-  }
 }
 .vm--overlay {
   background-color: rgba(10, 10, 10, 0.5) !important;
@@ -251,22 +248,6 @@
 }
 
 .home-creation-completed-modal {
-  &__event-name {
-    margin: 0 0 1rem 0;
-    b {
-      margin-left: 0.5rem;
-      @include text-size("mdi");
-    }
-  }
-  &__event-detail {
-    margin: 0 0 1rem 0;
-    &--description {
-      a {
-        text-decoration: underline !important;
-      }
-      @include invalidated-a-style;
-    }
-  }
   &__invitation {
     &--title {
       margin: 0 0 0.5rem 0;
@@ -274,13 +255,6 @@
     &__content {
       @media screen and (min-width: $small+px) {
         display: flex;
-      }
-      &--title {
-        margin: 0 0 5px 0;
-        @include text-size("normal");
-        @media screen and (min-width: $small+px) {
-          margin: 10px 5px 0 0;
-        }
       }
       &__detail {
         @include text-size("normal");
@@ -303,11 +277,25 @@
           color: $admin-primary;
           padding: 0;
           margin-left: 5px;
-          .material-icons {
-            font-size: 18px;
+
+          & > .check-icon {
+            color: #3ba73b;
           }
         }
       }
+    }
+  }
+
+  &__footer {
+    display: flex;
+    justify-content: flex-end;
+
+    & > .hide-button {
+      @include home-button-text($color: $admin-primary, $show-border: false);
+      margin-right: 1rem;
+    }
+    & > .room-access-button {
+      @include home-button-text;
     }
   }
 }

--- a/app/front/assets/scss/home/variables.scss
+++ b/app/front/assets/scss/home/variables.scss
@@ -19,6 +19,7 @@
   white-space: nowrap;
   border: 2px solid $color;
   border-radius: 4px;
+  line-height: 1;
   @if not $show-border {
     border-color: transparent;
   }

--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -552,12 +552,11 @@
     font-size: 8px;
     background-color: $primary;
     color: white;
-    padding: 0.25em 0.5em;
+    padding: 0.2em 0.8rem;
     margin-top: -1.5em;
     margin-left: -1.6em;
     border-top-left-radius: 4px;
     border-bottom-right-radius: 5px;
-    min-width: 7rem;
   }
   .sender-non-badge {
     display: inline-block;
@@ -581,6 +580,10 @@
 
   .badgecomment {
     padding: 0.75em 0.8em 0.35em !important;
+  }
+
+  .url-to-link__link {
+    color: rgb(47, 82, 199);
   }
   & > .comment,
   .reaction {
@@ -615,7 +618,6 @@
         -webkit-box-orient: vertical;
         -webkit-line-clamp: 2;
         overflow: hidden;
-        margin-left: 0.6rem;
         &:hover {
           text-decoration: underline;
           cursor: pointer;
@@ -698,27 +700,37 @@
         align-self: center; // NOTE: for safari (yuta-ike)
       }
 
-      & > .long-text {
-        flex: 1;
-        display: -webkit-box;
-        color: $text-gray;
-        font-style: oblique;
-        word-break: break-all;
-        overflow-wrap: anywhere;
-        -webkit-box-orient: vertical;
-        -webkit-line-clamp: 1;
-        overflow: hidden;
-        margin-left: 0.6rem;
-        &:hover {
-          text-decoration: underline;
-          cursor: pointer;
+      & > .reaction-link {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        width: 100%;
+
+        & > .icon {
+          color: $text-gray;
         }
-      }
-      & > .material-icons {
-        margin-left: 1em;
-        color: $text-gray;
-        font-size: 1rem;
-        cursor: pointer;
+
+        & > .long-text {
+          flex: 1;
+          display: -webkit-box;
+          color: $text-gray;
+          font-style: oblique;
+          word-break: break-all;
+          overflow-wrap: anywhere;
+          -webkit-box-orient: vertical;
+          -webkit-line-clamp: 1;
+          overflow: hidden;
+          margin-left: 0.6rem;
+          text-align: left;
+          line-height: 1;
+        }
+
+        &:hover {
+          & > .long-text {
+            text-decoration: underline;
+            cursor: pointer;
+          }
+        }
       }
     }
     .icon-wrapper {

--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -620,6 +620,14 @@
     border-radius: 5px;
     box-shadow: 0 1px 6px rgba(0, 0, 0, 0.15);
     overflow: visible;
+    transition: border 3s ease-out, box-shadow 3s ease-out;
+
+    // スクロール時のハイライトで利用するCSS / highlightクラスはjsで動的に追加される
+    &.highlight {
+      transition: none;
+      border: 1px solid $primary;
+      box-shadow: 0px 1px 10px rgba($primary, 0.9);
+    }
 
     .main-contents {
       display: flex;
@@ -630,19 +638,22 @@
         word-break: break-all;
         overflow-wrap: anywhere;
         margin-left: 0.5em;
-      }
-      .long-text {
-        flex: 1;
-        display: -webkit-box;
-        color: $text-gray;
-        word-break: break-all;
-        overflow-wrap: anywhere;
-        -webkit-box-orient: vertical;
-        -webkit-line-clamp: 2;
-        overflow: hidden;
-        &:hover {
-          text-decoration: underline;
-          cursor: pointer;
+        & > .long-text {
+          flex: 1;
+          display: -webkit-box;
+          color: $text-gray;
+          font-size: 80%;
+          text-align: left;
+          word-break: break-all;
+          overflow-wrap: anywhere;
+          margin-bottom: 0.3rem;
+          -webkit-box-orient: vertical;
+          -webkit-line-clamp: 2;
+          overflow: hidden;
+          &:hover {
+            text-decoration: underline;
+            cursor: pointer;
+          }
         }
       }
     }

--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -148,6 +148,7 @@
     }
     &--text {
       flex: 1;
+      font-size: 14px;
     }
     &--close-icon {
       flex-shrink: 0;

--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -2,9 +2,10 @@
   color: $color;
   border: 2px solid;
   background-color: white;
-  padding: 0px 20px;
+  padding: 4px 20px;
   border-radius: 99px;
   white-space: nowrap;
+  line-height: 1;
   &:hover {
     @if $color == $primary {
       background-color: rgba(242, 141, 47, 0.2);
@@ -51,7 +52,7 @@
     display: flex;
     position: relative;
     align-items: center;
-    padding: 0.2em 0.3em 0;
+    padding: 0 1rem;
     background-color: $primary;
     color: white;
     min-height: 3em;
@@ -79,24 +80,20 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      transition: all 0.3s;
+      transition: all 0.1s;
 
       &:hover {
-        background: $hover-button-background;
+        background: rgba(0, 0, 0, 0.08);
       }
 
       &:active {
-        background: $active-button-background;
+        background: rgba(0, 0, 0, 0.08);
       }
 
       &:disabled {
         color: rgba(204, 204, 204, 0.5);
         background: transparent;
         cursor: default;
-      }
-
-      & > .material-icons {
-        font-size: 1.5em;
       }
     }
   }
@@ -124,14 +121,18 @@
     &--download {
       color: $admin-primary;
       cursor: pointer;
-      & > .material-icons {
-        font-size: 1rem;
-      }
+      display: flex;
+      align-items: center;
+      @include text-size($size: "sm");
+
       & > .text {
         text-decoration: underline;
+        margin-left: 0.3rem;
       }
-      @include text-size($size: "sm");
-      @include material-icons-in-text;
+
+      &:hover {
+        opacity: 0.8;
+      }
     }
   }
 
@@ -142,6 +143,9 @@
     background-color: white;
     padding: 10px 5px;
     border-bottom: 1px solid rgb(239, 239, 239);
+    & > .icon {
+      transform: rotate(20deg);
+    }
     &--text {
       flex: 1;
     }
@@ -173,12 +177,12 @@
   width: 1.7rem;
   height: 1.7rem;
   padding: 0;
-  // margin: 0 0 0.35em 0.4rem;
   margin-right: 0.6rem;
   background: transparent;
   border: none;
-  //background-color: red;
-  & > .material-icons {
+
+  & > .icon {
+    display: flex;
     font-size: 1.1rem;
     padding: 0.3rem;
     width: 1.7rem;
@@ -186,6 +190,7 @@
     color: $text-gray;
     border-radius: 100%;
     transform: rotate(20deg);
+
     &:hover,
     &:focus {
       color: $text-gray;
@@ -675,27 +680,44 @@
       .badges {
         display: flex;
         align-items: flex-end;
-        .reply-icon,
-        .bg-good-icon {
+
+        & > .pin-icon,
+        & > .reply-icon,
+        & > .bg-good-icon {
           border: none;
           background: transparent;
-          padding: 0;
           width: 1.7rem;
           height: 1.7rem;
+          border-radius: 100%;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          margin-left: 0.5rem;
+          color: $text-gray;
 
-          & > .material-icons {
-            font-size: 1.3rem;
-            padding: 0.2rem;
+          &:hover {
+            color: $text-gray;
+            background-color: $placeholder-gray;
+          }
+
+          & > .icon {
             width: 1.7rem;
             height: 1.7rem;
-            color: $text-gray;
-            border-radius: 100%;
-            &:hover,
-            &:focus {
-              color: $text-gray;
-              background-color: $placeholder-gray;
+            display: flex;
+            align-items: center;
+            justify-items: center;
+          }
+
+          &.pin-icon {
+            & > .icon {
+              transform: rotate(20deg);
+
+              &.selected {
+                color: #ff542f;
+              }
             }
           }
+
           & > .answer-reply {
             &:hover {
               color: $answer-label;
@@ -704,13 +726,7 @@
               color: $answer-label;
             }
           }
-        }
-        .bg-good-icon {
-          margin-left: 0.5rem;
-          & > .material-icons {
-            font-size: 1.1rem;
-            padding: 0.3rem;
-          }
+
           .selected {
             transform: rotate(-20deg);
           }
@@ -735,6 +751,27 @@
         margin: 0;
         margin-right: 0.5em;
         align-self: center; // NOTE: for safari (yuta-ike)
+
+        & > .reaction-badge {
+          width: 1.3rem;
+          height: 1.3rem;
+          line-height: 1.1rem;
+          border-radius: 100%;
+          text-align: center;
+          color: #fff;
+          position: absolute;
+          bottom: -0.1rem;
+          right: -0.9rem;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+
+          & > .icon {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+          }
+        }
       }
 
       & > .reaction-link {
@@ -844,7 +881,6 @@
         padding: 0.25rem;
         width: 1.1rem;
         height: 1.1rem;
-        transform: rotate(-15deg);
       }
     }
   }

--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -32,6 +32,7 @@
   display: flex;
   flex-direction: column;
   width: 100vw;
+  padding-bottom: 0.75rem;
 }
 
 @media screen and (min-width: 440px) {
@@ -135,15 +136,31 @@
   }
 
   &__bookmark {
-    display: flex;
     position: relative;
-    z-index: -1;
+    display: flex;
+    align-items: center;
     background-color: white;
     padding: 10px 5px;
-    // box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.25);
     border-bottom: 1px solid rgb(239, 239, 239);
     &--text {
       flex: 1;
+    }
+    &--close-icon {
+      flex-shrink: 0;
+      align-self: flex-start;
+      margin-left: 10px;
+      color: $text-gray;
+      border-radius: 100%;
+      width: 30px;
+      height: 30px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: all 0.1s;
+
+      &:hover {
+        background: rgba($black, 0.08);
+      }
     }
     & > .chatitem__bookmark {
       margin-right: 10px;
@@ -202,6 +219,7 @@
       scroll-snap-type: y mandatory;
       overflow-y: scroll;
       padding: 1em 1rem;
+      @include scrollbar-hidden;
     }
 
     .list-complete {
@@ -723,6 +741,7 @@
           margin-left: 0.6rem;
           text-align: left;
           line-height: 1;
+          font-size: 13px;
         }
 
         &:hover {

--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -333,25 +333,21 @@
 
   & > .message-badge {
     position: absolute;
-    width: 100%;
-    max-width: 200px;
-    bottom: 1em;
+    bottom: 0.5em;
     left: 50%;
-    transform: translateX(-50%);
-    background: white;
-    padding: 0.5em 2em;
-    border-radius: 999px;
-    border: 2px solid rgb(56, 137, 230);
-    box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
-    border: 1px solid rgb(212, 212, 212);
-    display: grid;
-    align-items: center;
+    transform: translate(-50%, 150%);
+    background: rgba($black, 0.5);
+    padding: 0.5em;
     z-index: 30;
-    transition: all 0.2s;
+    width: 32px;
+    height: 32px;
+    border-radius: 100%;
+    transition: all 0.1s;
+    color: white;
+    stroke-width: 4px;
 
-    &:hover {
-      background: rgb(250, 250, 250);
-      transform: translateX(-50%) scale(1.05);
+    &.isNotify {
+      transform: translate(-50%, 0%);
     }
   }
 }
@@ -426,24 +422,25 @@
   }
   & > .textarea-footer {
     display: flex;
-    align-items: flex-end;
+    align-items: center;
     padding: 0em 1em 0.5em;
     justify-content: flex-end;
     & > .submit-button {
       position: relative;
       flex-shrink: 0;
-      width: 2.4em;
-      height: 2.4em;
+      width: 24px;
+      height: 24px;
       vertical-align: middle;
       text-align: center;
       border: none;
       background: transparent;
-      border-radius: 10px;
       display: grid;
       align-items: end;
+      padding: 0;
       color: $primary;
       &:disabled {
         color: rgb(172, 172, 172);
+        cursor: default;
       }
 
       & > .question-badge {
@@ -452,13 +449,18 @@
         height: 0.75rem;
         line-height: 0.75rem;
         border-radius: 100%;
-        font-size: 0.5rem;
+        font-size: 0.4rem;
         font-weight: bold;
         text-align: center;
         background: rgb(48, 135, 248);
         color: white;
-        bottom: -0.15rem;
-        right: 0.4rem;
+        bottom: 0;
+        right: -0.3rem;
+      }
+      &:disabled {
+        & > .question-badge {
+          background: $disabled-gray;
+        }
       }
     }
     .admin {
@@ -504,20 +506,20 @@
     width: 100%;
     display: flex;
     margin-right: -4px;
-    padding: 0.5em 1em;
+    padding: 0.3em 14px;
     align-items: center;
     font-size: 80%;
 
     & > .reply-type {
       color: white;
     }
-    .reply {
+    & .reply {
       background-color: $syoyu;
       border-radius: 5px;
       padding: 0.15em 0.5em;
     }
 
-    .answer {
+    & .answer {
       background-color: $answer-label;
       border-radius: 5px;
       padding: 0.15em 0.5em;
@@ -534,15 +536,17 @@
       flex: 1;
       margin: 0 0.5rem;
     }
-    & > .material-icons {
-      display: inline;
-      font-size: 16px;
-      color: $text-gray;
+
+    & > .reply-close-button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 24px;
+      height: 24px;
+      border-radius: 100%;
+      padding: 0;
       &:hover {
-        color: $black;
-      }
-      &:active {
-        color: $black;
+        background: rgba($black, 0.08);
       }
     }
   }

--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -317,6 +317,10 @@
       transition: all 0.2s;
       outline-color: rgb(207, 13, 13);
 
+      & > .icon {
+        display: flex;
+      }
+
       &:hover:not(:disabled),
       &:active:not(:disabled) {
         background: white;

--- a/app/front/assets/scss/sushiselect.scss
+++ b/app/front/assets/scss/sushiselect.scss
@@ -65,9 +65,8 @@
     &--help {
       position: relative;
       @include material-icons-in-text;
-      .material-icons {
+      & > .icon {
         margin-left: 0.5rem;
-        font-size: 1rem;
         &:hover {
           cursor: pointer;
           color: $primary;
@@ -76,7 +75,7 @@
       &--message {
         display: none;
         position: absolute;
-        left: 10px;
+        right: 0;
         width: 150px;
         background-color: white;
         padding: 5px 10px;
@@ -84,7 +83,7 @@
         border-radius: 4px;
         @include text-size("sm");
       }
-      .material-icons:hover + &--message {
+      & > .icon:hover + &--message {
         display: block;
       }
     }

--- a/app/front/components/ChatRoom.vue
+++ b/app/front/components/ChatRoom.vue
@@ -59,13 +59,8 @@
           :topic-id="topicId"
         />
       </div>
-      <button
-        class="message-badge"
-        :style="{ transform: `translate(-50%, ${isNotify ? 0 : 150}%)` }"
-        @click="clickScroll"
-      >
-        最新のコメント
-        <div class="material-icons">arrow_downward</div>
+      <button class="message-badge" :class="{ isNotify }" @click="clickScroll">
+        <ArrowDownIcon size="1.2x"></ArrowDownIcon>
       </button>
     </div>
     <TextArea
@@ -82,7 +77,7 @@
 import Vue from "vue"
 import type { PropOptions } from "vue"
 import throttle from "lodash.throttle"
-import { XIcon, ChevronUpIcon } from "vue-feather-icons"
+import { XIcon, ChevronUpIcon, ArrowDownIcon } from "vue-feather-icons"
 import { ChatItemModel, TopicState } from "sushi-chat-shared"
 import AnalysisGraph from "./AnalysisGraph.vue"
 import TopicHeader from "@/components/TopicHeader.vue"
@@ -109,6 +104,7 @@ export default Vue.extend({
     FavoriteButton,
     AnalysisGraph,
     XIcon,
+    ArrowDownIcon,
     ChevronUpIcon,
   },
   props: {

--- a/app/front/components/FavoriteButton.vue
+++ b/app/front/components/FavoriteButton.vue
@@ -2,7 +2,7 @@
   <div class="heart-button-wraper">
     <div v-for="c of count" :key="c.id">
       <span
-        class="heart-button material-icons"
+        class="heart-button"
         :class="{
           'heart-button-animation': stampAnimationFinished[c.id] === false,
         }"
@@ -12,10 +12,10 @@
           left: `${c.x}%`,
         }"
       >
-        favorite
+        <HeartIcon></HeartIcon>
       </span>
       <span
-        class="heart-button material-icons"
+        class="heart-button"
         :class="{
           'heart-button-animation': stampAnimationFinished[c.id] === false,
         }"
@@ -25,22 +25,24 @@
           left: `${c.x + 10}%`,
         }"
       >
-        favorite
+        <HeartIcon></HeartIcon>
       </span>
     </div>
 
     <button
       class="stamp-submit-button"
       :disabled="disabled"
+      aira-label="ハート"
       @click="clickFavorite"
     >
-      <span class="material-icons"> favorite </span>
+      <HeartIcon :size="24" decorative class="icon"></HeartIcon>
     </button>
   </div>
 </template>
 <script lang="ts">
 import Vue from "vue"
 import { StampModel } from "sushi-chat-shared"
+import HeartIcon from "vue-material-design-icons/Heart.vue"
 import { randomWaitedLoop } from "@/utils/waitedLoop"
 import { HSLColor, getRandomColor } from "@/utils/color"
 import { StampStore } from "~/store"
@@ -60,6 +62,9 @@ export type DataType = {
 
 export default Vue.extend({
   name: "FavoriteButton",
+  components: {
+    HeartIcon,
+  },
   props: {
     disabled: {
       type: Boolean,

--- a/app/front/components/Home/CreationCompletedModal.vue
+++ b/app/front/components/Home/CreationCompletedModal.vue
@@ -10,19 +10,6 @@
       >」が作成されました</template
     >
     <template #content>
-      <!-- <section class="home-creation-completed-modal__event-name">
-        イベント名：
-      </section> -->
-      <!-- <section class="home-creation-completed-modal__event-detail">
-        <div class="home-creation-completed-modal__event-detail--description">
-          <NuxtLink :to="'/?user=admin&roomId=' + roomId"
-            >イベントページをみる→</NuxtLink
-          >
-        </div>
-        <div class="home-creation-completed-modal__event-detail--additional">
-          （イベントページはマイページからも確認できます）
-        </div>
-      </section> -->
       <section
         class="home-creation-completed-modal__invitation"
         style="margin-bottom: 1rem"
@@ -31,31 +18,20 @@
           🍣 参加者URL
         </div>
         <div class="home-creation-completed-modal__invitation__content">
-          <!-- <div
-            class="home-creation-completed-modal__invitation__content--title"
-          >
-            招待リンク
-          </div> -->
           <div
             class="home-creation-completed-modal__invitation__content__detail"
           >
             <div
-              class="
-                home-creation-completed-modal__invitation__content__detail--url
-              "
+              class=" home-creation-completed-modal__invitation__content__detail--url"
             >
               {{ url }}
             </div>
             <button
-              class="
-                home-creation-completed-modal__invitation__content__detail--button
-              "
+              class=" home-creation-completed-modal__invitation__content__detail--button"
               @click="copy(url, 0)"
             >
               <CheckIcon v-if="copyCompleted" class="check-icon"></CheckIcon>
               <CopyIcon v-else></CopyIcon>
-              <!-- <span v-if="copyCompleted" class="material-icons"> done </span> -->
-              <!-- <span v-else class="material-icons"> content_copy </span> -->
             </button>
           </div>
         </div>
@@ -65,25 +41,16 @@
           🍣 共同管理者の招待URL
         </div>
         <div class="home-creation-completed-modal__invitation__content">
-          <!-- <div
-            class="home-creation-completed-modal__invitation__content--title"
-          >
-            招待リンク
-          </div> -->
           <div
             class="home-creation-completed-modal__invitation__content__detail"
           >
             <div
-              class="
-                home-creation-completed-modal__invitation__content__detail--url
-              "
+              class=" home-creation-completed-modal__invitation__content__detail--url"
             >
               {{ adminUrl }}
             </div>
             <button
-              class="
-                home-creation-completed-modal__invitation__content__detail--button
-              "
+              class=" home-creation-completed-modal__invitation__content__detail--button"
               @click="copy(adminUrl, 1)"
             >
               <CheckIcon

--- a/app/front/components/Home/CreationCompletedModal.vue
+++ b/app/front/components/Home/CreationCompletedModal.vue
@@ -5,12 +5,15 @@
     :click-to-close="false"
     @before-open="beforeOpen"
   >
-    <template #title>イベントが作成されました</template>
+    <template #title
+      >「<b>{{ title }}</b
+      >」が作成されました</template
+    >
     <template #content>
-      <section class="home-creation-completed-modal__event-name">
-        イベント名：<b>{{ title }}</b>
-      </section>
-      <section class="home-creation-completed-modal__event-detail">
+      <!-- <section class="home-creation-completed-modal__event-name">
+        イベント名：
+      </section> -->
+      <!-- <section class="home-creation-completed-modal__event-detail">
         <div class="home-creation-completed-modal__event-detail--description">
           <NuxtLink :to="'/?user=admin&roomId=' + roomId"
             >イベントページをみる→</NuxtLink
@@ -19,20 +22,20 @@
         <div class="home-creation-completed-modal__event-detail--additional">
           （イベントページはマイページからも確認できます）
         </div>
-      </section>
+      </section> -->
       <section
         class="home-creation-completed-modal__invitation"
         style="margin-bottom: 1rem"
       >
         <div class="home-creation-completed-modal__invitation--title">
-          🍣 参加者を招待する
+          🍣 参加者URL
         </div>
         <div class="home-creation-completed-modal__invitation__content">
-          <div
+          <!-- <div
             class="home-creation-completed-modal__invitation__content--title"
           >
             招待リンク
-          </div>
+          </div> -->
           <div
             class="home-creation-completed-modal__invitation__content__detail"
           >
@@ -49,22 +52,24 @@
               "
               @click="copy(url, 0)"
             >
-              <span v-if="copyCompleted" class="material-icons"> done </span>
-              <span v-else class="material-icons"> content_copy </span>
+              <CheckIcon v-if="copyCompleted" class="check-icon"></CheckIcon>
+              <CopyIcon v-else></CopyIcon>
+              <!-- <span v-if="copyCompleted" class="material-icons"> done </span> -->
+              <!-- <span v-else class="material-icons"> content_copy </span> -->
             </button>
           </div>
         </div>
       </section>
       <section class="home-creation-completed-modal__invitation">
         <div class="home-creation-completed-modal__invitation--title">
-          🍣 共同管理者を招待する
+          🍣 共同管理者の招待URL
         </div>
         <div class="home-creation-completed-modal__invitation__content">
-          <div
+          <!-- <div
             class="home-creation-completed-modal__invitation__content--title"
           >
             招待リンク
-          </div>
+          </div> -->
           <div
             class="home-creation-completed-modal__invitation__content__detail"
           >
@@ -81,25 +86,32 @@
               "
               @click="copy(adminUrl, 1)"
             >
-              <span v-if="copyAdminCompleted" class="material-icons">
-                done
-              </span>
-              <span v-else class="material-icons"> content_copy </span>
+              <CheckIcon
+                v-if="copyAdminCompleted"
+                class="check-icon"
+              ></CheckIcon>
+              <CopyIcon v-else></CopyIcon>
             </button>
           </div>
         </div>
       </section>
     </template>
     <template #hide-button>
-      <NuxtLink to="/home" class="home-modal__hide-button">
-        マイページに戻る
-      </NuxtLink>
+      <div class="home-creation-completed-modal__footer">
+        <NuxtLink to="/home" class="hide-button"> マイページに戻る </NuxtLink>
+        <NuxtLink
+          :to="'/?user=admin&roomId=' + roomId"
+          class="room-access-button"
+          >ルームを見る</NuxtLink
+        >
+      </div>
     </template>
   </Modal>
 </template>
 
 <script lang="ts">
 import Vue from "vue"
+import { CheckIcon, CopyIcon } from "vue-feather-icons"
 import Modal from "@/components/Home/Modal.vue"
 
 type DataType = {
@@ -114,6 +126,8 @@ export default Vue.extend({
   name: "HomeCreationCompletedModal",
   components: {
     Modal,
+    CopyIcon,
+    CheckIcon,
   },
   layout: "home",
   data(): DataType {

--- a/app/front/components/Home/InviteSuccess.vue
+++ b/app/front/components/Home/InviteSuccess.vue
@@ -1,105 +1,84 @@
 <template>
   <Modal
     name="home-invite-success-modal"
-    class="home-invite-success-modal"
+    class="home-creation-completed-modal"
     :click-to-close="false"
     @before-open="beforeOpen"
   >
-    <template #title>管理者登録が完了しました</template>
+    <template #title
+      >「<b>{{ title }}</b
+      >」に管理者として参加できるようになりました</template
+    >
     <template #content>
-      <section class="home-creation-completed-modal__event-name">
-        イベント名：<b>{{ title }}</b>
-      </section>
-      <section class="home-creation-completed-modal__event-detail">
-        <div class="home-creation-completed-modal__event-detail--description">
-          <NuxtLink :to="'/?user=admin&roomId=' + roomId"
-            >イベントページをみる→</NuxtLink
-          >
-        </div>
-        <div class="home-creation-completed-modal__event-detail--additional">
-          （イベントページはマイページからも確認できます）
-        </div>
-      </section>
       <section
         class="home-creation-completed-modal__invitation"
         style="margin-bottom: 1rem"
       >
         <div class="home-creation-completed-modal__invitation--title">
-          🍣 参加者を招待する
+          🍣 参加者URL
         </div>
         <div class="home-creation-completed-modal__invitation__content">
-          <div
-            class="home-creation-completed-modal__invitation__content--title"
-          >
-            招待リンク
-          </div>
           <div
             class="home-creation-completed-modal__invitation__content__detail"
           >
             <div
-              class="
-                home-creation-completed-modal__invitation__content__detail--url
-              "
+              class=" home-creation-completed-modal__invitation__content__detail--url"
             >
               {{ url }}
             </div>
             <button
-              class="
-                home-creation-completed-modal__invitation__content__detail--button
-              "
+              class=" home-creation-completed-modal__invitation__content__detail--button"
               @click="copy(url, 0)"
             >
-              <span v-if="copyCompleted" class="material-icons"> done </span>
-              <span v-else class="material-icons"> content_copy </span>
+              <CheckIcon v-if="copyCompleted" class="check-icon"></CheckIcon>
+              <CopyIcon v-else></CopyIcon>
             </button>
           </div>
         </div>
       </section>
       <section class="home-creation-completed-modal__invitation">
         <div class="home-creation-completed-modal__invitation--title">
-          🍣 共同管理者を招待する
+          🍣 共同管理者の招待URL
         </div>
         <div class="home-creation-completed-modal__invitation__content">
-          <div
-            class="home-creation-completed-modal__invitation__content--title"
-          >
-            招待リンク
-          </div>
           <div
             class="home-creation-completed-modal__invitation__content__detail"
           >
             <div
-              class="
-                home-creation-completed-modal__invitation__content__detail--url
-              "
+              class=" home-creation-completed-modal__invitation__content__detail--url"
             >
               {{ adminUrl }}
             </div>
             <button
-              class="
-                home-creation-completed-modal__invitation__content__detail--button
-              "
+              class=" home-creation-completed-modal__invitation__content__detail--button"
               @click="copy(adminUrl, 1)"
             >
-              <span v-if="copyAdminCompleted" class="material-icons">
-                done
-              </span>
-              <span v-else class="material-icons"> content_copy </span>
+              <CheckIcon
+                v-if="copyAdminCompleted"
+                class="check-icon"
+              ></CheckIcon>
+              <CopyIcon v-else></CopyIcon>
             </button>
           </div>
         </div>
       </section>
     </template>
     <template #hide-button>
-      <NuxtLink to="/home" class="home-modal__hide-button">
-        マイページに戻る
-      </NuxtLink>
+      <div class="home-creation-completed-modal__footer">
+        <NuxtLink to="/home" class="hide-button"> マイページに戻る </NuxtLink>
+        <NuxtLink
+          :to="'/?user=admin&roomId=' + roomId"
+          class="room-access-button"
+          >ルームを見る</NuxtLink
+        >
+      </div>
     </template>
   </Modal>
 </template>
 
 <script lang="ts">
 import Vue from "vue"
+import { CheckIcon, CopyIcon } from "vue-feather-icons"
 import Modal from "@/components/Home/Modal.vue"
 
 type DataType = {
@@ -115,6 +94,8 @@ export default Vue.extend({
   name: "InviteSuccess",
   components: {
     Modal,
+    CopyIcon,
+    CheckIcon,
   },
   layout: "home",
   data(): DataType {

--- a/app/front/components/Message.vue
+++ b/app/front/components/Message.vue
@@ -37,17 +37,16 @@
           <UrlToLink :text="message.content" />
         </div>
         <div v-else class="text">
-          <span
+          <p
             class="long-text"
             :style="{ color: 'gray', fontSize: '80%' }"
             @click.stop
           >
-            <UrlToLink
-              v-if="message.type != 'answer'"
-              :text="`> ` + message.quote.content"
-            />
-            <UrlToLink v-else :text="`Q. ` + message.quote.content" />
-          </span>
+            <template v-if="message.type != 'answer'">
+              > {{ message.quote.content }}
+            </template>
+            <template v-else> Q. {{ message.quote.content }} </template>
+          </p>
           <UrlToLink :text="message.content" />
         </div>
       </div>
@@ -104,13 +103,12 @@
           thumb_up
         </div>
       </div>
-      <div class="long-text">
-        {{ message.quote.content }}
-      </div>
-      <!-- quoteのmessageにスクロール -->
-      <span class="material-icons" @click="scrolltoMessage(message.quote.id)">
-        north_west
-      </span>
+      <button class="reaction-link" @click="scrolltoMessage(message.quote.id)">
+        <div class="long-text">
+          {{ message.quote.content }}
+        </div>
+        <ArrowUpLeftIcon class="icon" size="1.2x"></ArrowUpLeftIcon>
+      </button>
     </article>
     <!--System Message-->
     <article
@@ -126,6 +124,7 @@
 import Vue from "vue"
 import type { PropOptions } from "vue"
 import { ChatItemModel } from "sushi-chat-shared"
+import { ArrowUpLeftIcon } from "vue-feather-icons"
 import UrlToLink from "@/components/UrlToLink.vue"
 import ICONS from "@/utils/icons"
 import { PinnedChatItemsStore, UserItemStore } from "~/store"
@@ -139,6 +138,7 @@ export default Vue.extend({
   name: "Message",
   components: {
     UrlToLink,
+    ArrowUpLeftIcon,
   },
   props: {
     message: {

--- a/app/front/components/Message.vue
+++ b/app/front/components/Message.vue
@@ -54,20 +54,26 @@
           {{ showTimestamp(message.timestamp) }}
         </div>
         <div class="badges">
-          <button
-            v-if="isAdminorSpeaker"
-            class="chatitem__bookmark"
-            @click="bookmark()"
-          >
-            <span class="material-icons" :class="{ selected: isBookMarked }"
-              >push_pin</span
-            >
+          <button v-if="isAdminorSpeaker" class="pin-icon" @click="bookmark()">
+            <PinIcon
+              :size="18"
+              :class="{ selected: isBookMarked }"
+              class="icon"
+            ></PinIcon>
           </button>
           <button class="reply-icon" @click="clickReply">
-            <span class="material-icons"> reply </span>
+            <ReplyIcon :size="20" class="icon"></ReplyIcon>
           </button>
-          <button class="bg-good-icon">
-            <span
+          <button
+            class="bg-good-icon"
+            :style="{
+              backgroundColor: isLikedChatItem ? icon.colorCode : undefined,
+              color: isLikedChatItem ? 'white' : undefined,
+              transform: isLikedChatItem ? 'rotate(-20deg)' : undefined,
+            }"
+          >
+            <ThumbUpIcon :size="19" class="icon"></ThumbUpIcon>
+            <!-- <span
               :style="{
                 backgroundColor: isLikedChatItem ? icon.colorCode : '',
                 color: isLikedChatItem ? 'white' : '',
@@ -77,7 +83,7 @@
               @click="clickThumbUp"
             >
               thumb_up
-            </span>
+            </span> -->
           </button>
         </div>
       </div>
@@ -94,12 +100,12 @@
           <img :src="icon.png" alt="" />
         </picture>
         <div
-          class="material-icons raction-badge"
+          class="reaction-badge"
           :style="{
             backgroundColor: icon.colorCode,
           }"
         >
-          thumb_up
+          <ThumbUpIcon class="icon" :size="13"></ThumbUpIcon>
         </div>
       </div>
       <button
@@ -130,6 +136,9 @@ import Vue from "vue"
 import type { PropOptions } from "vue"
 import { ChatItemModel } from "sushi-chat-shared"
 import { ArrowUpLeftIcon } from "vue-feather-icons"
+import PinIcon from "vue-material-design-icons/Pin.vue"
+import ReplyIcon from "vue-material-design-icons/Reply.vue"
+import ThumbUpIcon from "vue-material-design-icons/ThumbUp.vue"
 import UrlToLink from "@/components/UrlToLink.vue"
 import ICONS from "@/utils/icons"
 import { PinnedChatItemsStore, UserItemStore } from "~/store"
@@ -144,6 +153,9 @@ export default Vue.extend({
   components: {
     UrlToLink,
     ArrowUpLeftIcon,
+    PinIcon,
+    ReplyIcon,
+    ThumbUpIcon,
   },
   props: {
     message: {

--- a/app/front/components/Message.vue
+++ b/app/front/components/Message.vue
@@ -85,7 +85,7 @@
     </article>
     <!--Reaction Message-->
     <article
-      v-else-if="message.type == 'reaction'"
+      v-else-if="message.type == 'reaction' && message.quote != null"
       :id="message.id"
       class="reaction"
     >
@@ -103,7 +103,10 @@
           thumb_up
         </div>
       </div>
-      <button class="reaction-link" @click="scrolltoMessage(message.quote.id)">
+      <button
+        class="reaction-link"
+        @click="if (message.quote != null) scrolltoMessage(message.quote.id)"
+      >
         <div class="long-text">
           {{ message.quote.content }}
         </div>
@@ -164,7 +167,6 @@ export default Vue.extend({
       return PinnedChatItemsStore.pinnedChatItems
     },
     isBookMarked(): boolean {
-      console.log(PinnedChatItemsStore.pinnedChatItems)
       return this.pinnedChatItems.includes(this.message.id)
     },
     isAdminorSpeaker(): boolean {

--- a/app/front/components/Message.vue
+++ b/app/front/components/Message.vue
@@ -71,6 +71,7 @@
               color: isLikedChatItem ? 'white' : undefined,
               transform: isLikedChatItem ? 'rotate(-20deg)' : undefined,
             }"
+            @click="clickThumbUp"
           >
             <ThumbUpIcon :size="19" class="icon"></ThumbUpIcon>
             <!-- <span

--- a/app/front/components/Message.vue
+++ b/app/front/components/Message.vue
@@ -30,23 +30,22 @@
           <div v-if="message.type == 'question'" class="question-badge">Q</div>
           <div v-if="message.type == 'answer'" class="answer-badge">A</div>
         </div>
-        <div
-          v-if="message.type == 'question' || message.quote == null"
-          class="text"
-        >
+        <div v-if="message.quote == null" class="text">
           <UrlToLink :text="message.content" />
         </div>
         <div v-else class="text">
-          <p
+          <button
             class="long-text"
-            :style="{ color: 'gray', fontSize: '80%' }"
-            @click.stop
+            @click.stop="
+              // NOTE: 型推論のためにifを追加
+              if (message.quote != null) scrolltoMessage(message.quote.id)
+            "
           >
             <template v-if="message.type != 'answer'">
               > {{ message.quote.content }}
             </template>
             <template v-else> Q. {{ message.quote.content }} </template>
-          </p>
+          </button>
           <UrlToLink :text="message.content" />
         </div>
       </div>
@@ -105,7 +104,10 @@
       </div>
       <button
         class="reaction-link"
-        @click="if (message.quote != null) scrolltoMessage(message.quote.id)"
+        @click="
+          // NOTE: 型推論のためにifを追加
+          if (message.quote != null) scrolltoMessage(message.quote.id)
+        "
       >
         <div class="long-text">
           {{ message.quote.content }}
@@ -192,6 +194,11 @@ export default Vue.extend({
           behavior: "smooth",
           block: "nearest",
         })
+        console.log(id)
+        element.classList.add("highlight")
+        setTimeout(() => {
+          element.classList.remove("highlight")
+        }, 0)
       }
     },
     // タイムスタンプを分、秒単位に変換

--- a/app/front/components/SelectIconModal.vue
+++ b/app/front/components/SelectIconModal.vue
@@ -43,7 +43,7 @@
         <div class="sushi-select__section--title">
           2. スピーカーの方は、セッション名をえらんでね
           <span class="sushi-select__section--help">
-            <span class="material-icons"> help_outline</span>
+            <HelpCircleIcon class="icon" size="1x"></HelpCircleIcon>
             <div class="sushi-select__section--help--message">
               自分のセッション内では、コメントが強調されます。また、メッセージのピン留めなどの機能が利用できます。
             </div>
@@ -87,11 +87,15 @@
 
 <script lang="ts">
 import Vue from "vue"
+import { HelpCircleIcon } from "vue-feather-icons"
 import ICONS from "@/utils/icons"
 import { TopicStore, UserItemStore } from "~/store"
 
 export default Vue.extend({
   name: "SelectIconModal",
+  components: {
+    HelpCircleIcon,
+  },
   props: {
     title: {
       type: String,

--- a/app/front/components/TextArea.vue
+++ b/app/front/components/TextArea.vue
@@ -11,7 +11,9 @@
       <div v-if="selectedChatItem.type !== 'reaction'" class="reply-content">
         {{ selectedChatItem.content }}
       </div>
-      <div class="material-icons" @click="deselectChatItem">close</div>
+      <button class="reply-close-button" @click="deselectChatItem">
+        <XIcon size="1.2x"></XIcon>
+      </button>
     </div>
     <div v-if="selectedChatItem === null" class="sender-badge-wrapper">
       <span v-if="isAdmin" class="sender-badge admin"> from 運営 </span>
@@ -51,7 +53,6 @@
         >
       </label>
       <button
-        type="submit"
         class="submit-button"
         :disabled="
           disabled || maxMessageLength < text.length || text.length == 0
@@ -61,8 +62,10 @@
         }"
         @click="sendMessage"
       >
-        <span class="material-icons"> send </span>
-        <div v-show="isQuestion" class="question-badge">Q</div>
+        <SendIcon></SendIcon>
+        <div v-show="isQuestion" class="question-badge" aria-hidden="true">
+          Q
+        </div>
       </button>
     </div>
   </section>
@@ -71,6 +74,7 @@
 import Vue from "vue"
 import type { PropOptions } from "vue"
 import { ChatItemModel } from "sushi-chat-shared"
+import { XIcon, SendIcon } from "vue-feather-icons"
 import KeyInstruction from "@/components/KeyInstruction.vue"
 import { UserItemStore } from "~/store"
 
@@ -84,6 +88,8 @@ export default Vue.extend({
   name: "TextArea",
   components: {
     KeyInstruction,
+    XIcon,
+    SendIcon,
   },
   props: {
     topicTitle: {

--- a/app/front/components/TopicHeader.vue
+++ b/app/front/components/TopicHeader.vue
@@ -38,11 +38,19 @@
         <span class="text">現在までのチャット履歴のダウンロード</span>
       </div>
     </div>
-    <div v-if="bookmarkContent !== ''" class="topic-header__bookmark">
-      <button class="chatitem__bookmark" @click="isBookMarked = !isBookMarked">
+    <div v-if="bookmarkContent != null" class="topic-header__bookmark">
+      <div class="chatitem__bookmark">
         <span class="material-icons selected">push_pin</span>
-      </button>
+      </div>
       <div class="topic-header__bookmark--text">{{ bookmarkContent }}</div>
+      <button
+        class="topic-header__bookmark--close-icon"
+        aria-label="ピン留めから外す"
+        title="ピン留めから外す"
+        @click="removeBookmark()"
+      >
+        <XCircleIcon size="1.2x" aria-hidden="true"></XCircleIcon>
+      </button>
     </div>
   </div>
 </template>
@@ -50,8 +58,9 @@
 import Vue from "vue"
 import type { PropOptions } from "vue"
 // import SidebarDrawer from "@/components/Sidebar/SidebarDrawer.vue"
-import { ChatItemPropType } from "~/models/contents"
-import { UserItemStore } from "~/store"
+import { ChatItemModel } from "sushi-chat-shared"
+import { XCircleIcon } from "vue-feather-icons"
+import { PinnedChatItemsStore, UserItemStore } from "~/store"
 
 type DataType = {
   isAllCommentShowed: boolean
@@ -62,6 +71,7 @@ export default Vue.extend({
   name: "TopicHeader",
   components: {
     // SidebarDrawer,
+    XCircleIcon,
   },
   props: {
     title: {
@@ -74,8 +84,8 @@ export default Vue.extend({
     },
     bookmarkItem: {
       type: Object,
-      required: true,
-    } as PropOptions<ChatItemPropType>,
+      default: undefined,
+    } as PropOptions<ChatItemModel | undefined>,
   },
   data(): DataType {
     return {
@@ -87,14 +97,11 @@ export default Vue.extend({
     isAdmin(): boolean {
       return UserItemStore.userItems.isAdmin
     },
-    bookmarkContent(): string {
-      if (
-        typeof this.bookmarkItem !== "undefined" &&
-        this.bookmarkItem.type !== "reaction"
-      ) {
-        return this.bookmarkItem.content
+    bookmarkContent(): string | undefined {
+      if (this.bookmarkItem?.type === "reaction") {
+        return
       }
-      return ""
+      return this.bookmarkItem?.content
     },
   },
   methods: {
@@ -108,6 +115,12 @@ export default Vue.extend({
     clickNotShowAll() {
       this.isAllCommentShowed = false
       this.$emit("click-not-show-all")
+    },
+    removeBookmark() {
+      console.log("removeBookmark")
+      if (this.bookmarkItem != null) {
+        PinnedChatItemsStore.delete(this.bookmarkItem?.id)
+      }
     },
   },
 })

--- a/app/front/components/TopicHeader.vue
+++ b/app/front/components/TopicHeader.vue
@@ -11,7 +11,7 @@
       </div>
       <div class="title">{{ title }}</div>
       <button class="more-button" @click="isOpenDetails = !isOpenDetails">
-        <span class="material-icons"> more_vert </span>
+        <MoreVerticalIcon></MoreVerticalIcon>
       </button>
     </div>
     <div v-if="isOpenDetails" class="topic-header__details">
@@ -34,13 +34,13 @@
       </div>
       <div class="topic-header__details--line" />
       <div class="topic-header__details--download" @click="clickDownload">
-        <span class="material-icons"> file_download </span>
+        <DownloadIcon size="1.2x"></DownloadIcon>
         <span class="text">現在までのチャット履歴のダウンロード</span>
       </div>
     </div>
     <div v-if="bookmarkContent != null" class="topic-header__bookmark">
       <div class="chatitem__bookmark">
-        <span class="material-icons selected">push_pin</span>
+        <PinIcon class="icon selected"></PinIcon>
       </div>
       <div class="topic-header__bookmark--text">{{ bookmarkContent }}</div>
       <button
@@ -59,7 +59,8 @@ import Vue from "vue"
 import type { PropOptions } from "vue"
 // import SidebarDrawer from "@/components/Sidebar/SidebarDrawer.vue"
 import { ChatItemModel } from "sushi-chat-shared"
-import { XCircleIcon } from "vue-feather-icons"
+import { DownloadIcon, MoreVerticalIcon, XCircleIcon } from "vue-feather-icons"
+import PinIcon from "vue-material-design-icons/Pin.vue"
 import { PinnedChatItemsStore, UserItemStore } from "~/store"
 
 type DataType = {
@@ -72,6 +73,9 @@ export default Vue.extend({
   components: {
     // SidebarDrawer,
     XCircleIcon,
+    PinIcon,
+    MoreVerticalIcon,
+    DownloadIcon,
   },
   props: {
     title: {

--- a/app/front/components/TopicHeader.vue
+++ b/app/front/components/TopicHeader.vue
@@ -10,8 +10,12 @@
         #<span style="font-size: 80%">{{ topicIndex }}</span>
       </div>
       <div class="title">{{ title }}</div>
-      <button class="more-button" @click="isOpenDetails = !isOpenDetails">
-        <MoreVerticalIcon></MoreVerticalIcon>
+      <button
+        class="more-button"
+        aria-label="メニューを開閉する"
+        @click="isOpenDetails = !isOpenDetails"
+      >
+        <MoreVerticalIcon aria-hidden="true"></MoreVerticalIcon>
       </button>
     </div>
     <div v-if="isOpenDetails" class="topic-header__details">
@@ -34,19 +38,23 @@
       </div>
       <div class="topic-header__details--line" />
       <div class="topic-header__details--download" @click="clickDownload">
-        <DownloadIcon size="1.2x"></DownloadIcon>
+        <DownloadIcon size="1.2x" aria-hidden="true"></DownloadIcon>
         <span class="text">現在までのチャット履歴のダウンロード</span>
       </div>
     </div>
     <div v-if="bookmarkContent != null" class="topic-header__bookmark">
       <div class="chatitem__bookmark">
-        <PinIcon class="icon selected"></PinIcon>
+        <PinIcon
+          class="icon selected"
+          aria-label="ピン留め"
+          title="ピン留め"
+        ></PinIcon>
       </div>
       <div class="topic-header__bookmark--text">{{ bookmarkContent }}</div>
       <button
         class="topic-header__bookmark--close-icon"
-        aria-label="ピン留めから外す"
-        title="ピン留めから外す"
+        aria-label="ピン留め解除"
+        title="ピン留め解除"
         @click="removeBookmark()"
       >
         <XCircleIcon size="1.2x" aria-hidden="true"></XCircleIcon>

--- a/app/front/components/UrlToLink.vue
+++ b/app/front/components/UrlToLink.vue
@@ -9,7 +9,14 @@
           <br v-else />
         </span>
       </span>
-      <a v-else :href="content" target="_blank" @click.stop>
+      <a
+        v-else
+        :href="content"
+        target="_blank"
+        class="url-to-link__link"
+        :title="content"
+        @click.stop
+      >
         {{ content }}
       </a>
     </span>

--- a/app/front/components/UrlToLink.vue
+++ b/app/front/components/UrlToLink.vue
@@ -13,6 +13,7 @@
         v-else
         :href="content"
         target="_blank"
+        rel="noopener noreferrer"
         class="url-to-link__link"
         :title="content"
         @click.stop

--- a/app/front/nuxt.config.js
+++ b/app/front/nuxt.config.js
@@ -132,7 +132,8 @@ export default {
   // WebFontLoader
   webfontloader: {
     google: {
-      families: ["M PLUS 1p:100,400,700", "Material Icons", "Material Icons Outlined"],
+      // FIXME: デグレが起きて旧バージョンを見たいケースのためにコメントアウトにしておく。不要になったら消す。
+      families: ["M PLUS 1p:100,400,700", /* "Material Icons", "Material Icons Outlined" */],
     },
   },
 

--- a/app/front/package.json
+++ b/app/front/package.json
@@ -28,6 +28,7 @@
     "vue-chartjs": "^3.5.1",
     "vue-feather-icons": "^5.1.0",
     "vue-js-modal": "^2.0.0-rc.6",
+    "vue-material-design-icons": "^4.13.0",
     "vuedraggable": "^2.24.3"
   },
   "devDependencies": {

--- a/app/front/pages/home.vue
+++ b/app/front/pages/home.vue
@@ -3,7 +3,7 @@
     <header class="home-top__header">マイページ</header>
     <section class="home-top__new-event">
       <NuxtLink to="/room/create" class="home-top__new-event--button">
-        <span class="material-icons"> add </span>新しいイベントを作成
+        <PlusIcon class="icon"></PlusIcon>新しいイベントを作成
       </NuxtLink>
     </section>
     <section v-if="ongoingRooms.length > 0" class="home-top__event">
@@ -108,6 +108,7 @@
 <script lang="ts">
 import Vue from "vue"
 import { RoomModel } from "sushi-chat-shared"
+import { PlusIcon } from "vue-feather-icons"
 import { DeviceStore, AuthStore } from "~/store"
 import { formatDate } from "~/utils/formatDate"
 
@@ -119,6 +120,9 @@ type AsyncDataType = {
 
 export default Vue.extend({
   name: "Home",
+  components: {
+    PlusIcon,
+  },
   layout: "home",
   middleware: "privateRoute",
   async asyncData({ app }): Promise<AsyncDataType> {

--- a/app/front/pages/invited.vue
+++ b/app/front/pages/invited.vue
@@ -11,7 +11,7 @@
           {{ room.state === "ongoing" ? "ルーム開催中" : "ルーム開始前" }}
         </div>
         <div class="not-started__button">
-          <button @click="regiaterAdmin">登録する</button>
+          <button @click="regiaterAdmin">招待を受ける</button>
         </div>
       </div>
       <InviteSuccess />
@@ -75,6 +75,7 @@ export default Vue.extend({
         {},
       )
       if (res.result === "error") {
+        window.alert("処理に失敗しました")
         throw new Error("管理者招待失敗")
       }
       console.log({

--- a/app/front/pages/room/create.vue
+++ b/app/front/pages/room/create.vue
@@ -65,7 +65,7 @@
                     :disabled="!canDeleteSessionInput"
                     @click="removeSession(idx)"
                   >
-                    <span class="material-icons"> remove </span>
+                    <MinusCircleIcon size="1.2x"></MinusCircleIcon>
                   </button>
                 </form>
                 <button
@@ -75,7 +75,7 @@
                       isDragging === true,
                   }"
                 >
-                  <span class="material-icons">menu</span>
+                  <MenuIcon size="1.2x"></MenuIcon>
                 </button>
               </div>
             </transition-group>
@@ -87,13 +87,15 @@
           class="home-create__room__add--button"
           @click="() => addSession()"
         >
-          <span class="material-icons"> add </span>セッションを追加
+          <PlusIcon class="icon" size="20px"></PlusIcon>
+          セッションを追加
         </button>
         <button
           class="home-create__room__add--collective-button"
           @click="$modal.show('home-add-sessions-modal')"
         >
-          <span class="material-icons"> add </span>まとめて追加
+          <PlusIcon class="icon" size="20px"></PlusIcon>
+          まとめて追加
         </button>
       </div>
     </section>
@@ -109,6 +111,8 @@
 import Vue from "vue"
 import VModal from "vue-js-modal"
 import draggable from "vuedraggable"
+import PlusIcon from "vue-material-design-icons/Plus.vue"
+import { MenuIcon, MinusCircleIcon } from "vue-feather-icons"
 import AddSessionsModal from "@/components/Home/AddSessionsModal.vue"
 import CreationCompletedModal from "@/components/Home/CreationCompletedModal.vue"
 
@@ -128,6 +132,9 @@ export default Vue.extend({
     AddSessionsModal,
     CreationCompletedModal,
     draggable,
+    PlusIcon,
+    MenuIcon,
+    MinusCircleIcon,
   },
   layout: "home",
   data(): DataType {

--- a/app/front/store/pinnedChatItems.ts
+++ b/app/front/store/pinnedChatItems.ts
@@ -28,11 +28,11 @@ export default class PinnedChatItems extends VuexModule {
 
   @Action({ rawError: true })
   public send({
-    topicId, 
-    chatItemId, 
+    topicId,
+    chatItemId,
   }: {
-    topicId: number,
-    chatItemId: string, 
+    topicId: number
+    chatItemId: string
   }) {
     const socket = buildSocket(AuthStore.idToken)
     socket.emit(
@@ -41,7 +41,7 @@ export default class PinnedChatItems extends VuexModule {
         topicId,
         chatItemId,
       },
-      (res: any) => {
+      (res) => {
         console.log(res)
       },
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -15152,6 +15152,11 @@ vue-loading-template@^1.3.2:
     vue-class-component "^6.0.0"
     vue-property-decorator "^6.0.0"
 
+vue-material-design-icons@^4.13.0:
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/vue-material-design-icons/-/vue-material-design-icons-4.13.0.tgz#8bab3335c4f906799493d5de52dafed853daa186"
+  integrity sha512-TwaWrvh4J49VdkV9Uzcbr/p3FBRiBthRkIrg6SUh7ogFUljdA2ySNoAYD9dTU+mJkANIn1A6MoD/PnyLONnkWg==
+
 vue-meta@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/vue-meta/-/vue-meta-2.4.0.tgz#a419fb4b4135ce965dab32ec641d1989c2ee4845"


### PR DESCRIPTION
close #264 #520 #506 

## やったこと
- **material iconsフォントを消し去った**
- reaction/メッセージの吹き出しのデザイン調整
- ピン留め解除ボタンを追加
![image](https://user-images.githubusercontent.com/38308823/135067608-5d9f3aca-e7dd-4d32-bc55-6b7d2c0bab27.png)
- スクロールバーを非表示
- 「最新のメッセージへ」のデザインを変更
![image](https://user-images.githubusercontent.com/38308823/135067643-bb35f28f-211c-4446-8fd4-4b77e84797bd.png)

- リアクションやリプライで元のメッセージをクリックした場合に、スクロールに加えて元のメッセージがハイライトされる処理を追加
![image](https://user-images.githubusercontent.com/38308823/135067535-d0354bc5-6dc2-45e2-b17e-d96be050a443.png)


<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
