### PR TITLE
not write error on client error

### DIFF
--- a/app/server/src/rest.ts
+++ b/app/server/src/rest.ts
@@ -238,7 +238,11 @@ export const restSetup = (
     res: Response,
     code = 500,
   ) => {
-    logError(route, error)
+    // サーバーエラーの時のみエラーログに書き込む
+    if (code >= 500) {
+      logError(route, error)
+    }
+
     res.status(code).send({
       result: "error",
       error: {


### PR DESCRIPTION
close #xxx

## やったこと
- クライアントエラーの時にエラーログを書き込まないようにした
  - エラーログがうるさく、本当に重要な通知を見逃してしまう危険がある
  - クライアントエラーは基本的にこちら側で対応することはできないもの。もしサーバー側の問題ならクライアントエラーでなくサーバーエラーにするべき。

## やっていないこと
- クライアントエラーとサーバーエラーの切り分け。
  - 現在、管理者認証必須のエンドポイントでトークンが渡されていない時のみクライアントエラーにしているが、存在しない部屋にアクセスした時など、他にもクライアントエラーにするべき箇所が多々ある。

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
