### PR TITLE
トピック変更のsocket通知修正

### DIFF
--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -177,21 +177,6 @@ export default Vue.extend({
         ChatItemStore.addOrUpdate(chatItem)
       })
       this.$socket().on("PUB_CHANGE_TOPIC_STATE", (res: any) => {
-        if (res.state === "ongoing") {
-          // 現在ongoingまたはpausedなトピックがあればfinishedにする
-          const t = Object.fromEntries(
-            Object.entries(this.topicStateItems).map(
-              ([topicId, topicState]) => [
-                topicId,
-                (topicState =
-                  topicState === "ongoing" || topicState === "paused"
-                    ? "finished"
-                    : topicState),
-              ],
-            ),
-          )
-          TopicStateItemStore.set(t)
-        }
         // クリックしたTopicのStateを変える
         TopicStateItemStore.change({ key: res.topicId, state: res.state })
       })

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -178,12 +178,15 @@ export default Vue.extend({
       })
       this.$socket().on("PUB_CHANGE_TOPIC_STATE", (res: any) => {
         if (res.state === "ongoing") {
-          // 現在ongoingなトピックがあればfinishedにする
+          // 現在ongoingまたはpausedなトピックがあればfinishedにする
           const t = Object.fromEntries(
             Object.entries(this.topicStateItems).map(
               ([topicId, topicState]) => [
                 topicId,
-                topicState === "ongoing" ? "finished" : topicState,
+                (topicState =
+                  topicState === "ongoing" || topicState === "paused"
+                    ? "finished"
+                    : topicState),
               ],
             ),
           )


### PR DESCRIPTION
#549 のあとで

## やったこと
- TopicStateの変更に対してフロント側でActiveなTopicを探していた実装から、フロントでは毎度受け取った状態の変更のみを行う

## やっていないこと
- #519 の現象はサーバーとも要確認

<!--
## スクリーンショット
-->

## 動作確認手順
#549 のあとに変更を取り込んで、動作を検証する

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
