### PR TITLE
スタンプの仕様と実装を変更

### DIFF
--- a/app/front/components/FavoriteButton.vue
+++ b/app/front/components/FavoriteButton.vue
@@ -91,18 +91,18 @@ export default Vue.extend({
   watch: {
     stamps(newValue, oldValue) {
       newValue = newValue.slice(oldValue.length)
-      if (newValue.length) {
+      if (newValue.length > 1) {
         randomWaitedLoop(2000 / newValue.length, 500, newValue.length, () => {
           this.emitHeart()
         })
+      } else if (newValue.length === 1) {
+        this.emitHeart()
       }
     },
   },
   methods: {
     clickFavorite() {
       if (this.disabled) return
-      // スタンプのアニメーション
-      this.emitHeart()
       // Storeに追加し、サーバーに反映
       StampStore.sendFavorite(this.topicId)
     },

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -195,7 +195,7 @@ export default Vue.extend({
       // スタンプ通知時の、SocketIOのコールバックの登録
       this.$socket().on("PUB_STAMP", (stamps: StampModel[]) => {
         stamps.forEach((stamp) => {
-          StampStore.add(stamp)
+          StampStore.addOrUpdate(stamp)
         })
       })
       // アクティブユーザー数のSocketIOのコールバックの登録

--- a/app/front/store/chatItems.ts
+++ b/app/front/store/chatItems.ts
@@ -81,13 +81,9 @@ export default class ChatItems extends VuexModule {
     })
     // サーバーに送信する
     const socket = buildSocket(AuthStore.idToken)
-    socket.emit(
-      "POST_CHAT_ITEM", 
-      params, 
-      (res: any) => {
-        console.log(res)
-      },
-    )
+    socket.emit("POST_CHAT_ITEM", params, (res) => {
+      console.log(res)
+    })
     console.log("send reaction: ", text)
   }
 
@@ -112,13 +108,9 @@ export default class ChatItems extends VuexModule {
     })
     // サーバーに反映する
     const socket = buildSocket(AuthStore.idToken)
-    socket.emit(
-      "POST_CHAT_ITEM", 
-      params, 
-      (res: any) => {
-        console.log(res)
-      },
-    )
+    socket.emit("POST_CHAT_ITEM", params, (res) => {
+      console.log(res)
+    })
     console.log("send reaction: ", message.content)
   }
 
@@ -143,12 +135,9 @@ export default class ChatItems extends VuexModule {
     })
     // サーバーに反映する
     const socket = buildSocket(AuthStore.idToken)
-    socket.emit("POST_CHAT_ITEM", 
-      params, 
-      (res: any) => {
-        console.log(res)
-      },
-    )
+    socket.emit("POST_CHAT_ITEM", params, (res) => {
+      console.log(res)
+    })
     console.log("send question: ", text)
   }
 
@@ -171,12 +160,9 @@ export default class ChatItems extends VuexModule {
     }
     // サーバーに反映する
     const socket = buildSocket(AuthStore.idToken)
-    socket.emit("POST_CHAT_ITEM", 
-      params, 
-      (res: any) => {
-        console.log(res)
-      },
-    )
+    socket.emit("POST_CHAT_ITEM", params, (res) => {
+      console.log(res)
+    })
     // ローカルに反映する
     this.add({
       id: params.id,

--- a/app/front/store/stamps.ts
+++ b/app/front/store/stamps.ts
@@ -21,17 +21,32 @@ export default class Stamps extends VuexModule {
     this._stamps.push(s)
   }
 
+  @Mutation
+  public update(s: StampModel) {
+    this._stamps = this._stamps.map((item) => (item.id === s.id ? s : item))
+  }
+
+  @Action({ rawError: true })
+  public addOrUpdate(s: StampModel) {
+    if (this._stamps.find(({ id }) => id === s.id)) {
+      this.update(s)
+    } else {
+      this.add(s)
+    }
+  }
+
   @Action({ rawError: true })
   public sendFavorite(topicId: number) {
     const socket = buildSocket(AuthStore.idToken)
+    const id = getUUID()
     // StampStoreは配信で追加する
-    // this.add({
-    //   id: getUUID(),
-    //   topicId,
-    //   timestamp: 1000, // TODO: 正しいタイムスタンプを設定する
-    //   createdAt: new Date().toISOString(),
-    // })
-    socket.emit("POST_STAMP", { topicId }, (res) => {
+    this.add({
+      id,
+      topicId,
+      timestamp: 1000, // TODO: 正しいタイムスタンプを設定する
+      createdAt: new Date().toISOString(),
+    })
+    socket.emit("POST_STAMP", { topicId, id }, (res) => {
       console.log(res)
     })
   }

--- a/app/front/store/stamps.ts
+++ b/app/front/store/stamps.ts
@@ -31,7 +31,7 @@ export default class Stamps extends VuexModule {
     //   timestamp: 1000, // TODO: 正しいタイムスタンプを設定する
     //   createdAt: new Date().toISOString(),
     // })
-    socket.emit("POST_STAMP", { topicId }, (res: any) => {
+    socket.emit("POST_STAMP", { topicId }, (res) => {
       console.log(res)
     })
   }

--- a/app/server/src/__test__/testStampService.ts
+++ b/app/server/src/__test__/testStampService.ts
@@ -75,7 +75,8 @@ describe("StampServiceのテスト", () => {
 
   describe("postのテスト", () => {
     test("正常系_stampを投稿する", async () => {
-      await stampService.post({ userId, topicId: 1 })
+      const stampId = uuid()
+      await stampService.post({ id: stampId, userId, topicId: 1 })
       // stampIntervalDeliveryのインターバル処理でスタンプで配信されるのを待つ
       await delay(200)
 
@@ -88,8 +89,9 @@ describe("StampServiceのテスト", () => {
     })
 
     test("異常系_OPEN状態でないTopicへはスタンプを投稿できない", async () => {
+      const stampId = uuid()
       await expect(() =>
-        stampService.post({ userId, topicId: 2 }),
+        stampService.post({ id: stampId, userId, topicId: 2 }),
       ).rejects.toThrowError()
     })
   })

--- a/app/server/src/domain/stamp/IStampFactory.ts
+++ b/app/server/src/domain/stamp/IStampFactory.ts
@@ -2,6 +2,7 @@ import Stamp from "./Stamp"
 
 interface IStampFactory {
   create(
+    id: string,
     userId: string,
     roomId: string,
     topicId: number,

--- a/app/server/src/infra/factory/StampFactory.ts
+++ b/app/server/src/infra/factory/StampFactory.ts
@@ -1,14 +1,14 @@
-import { v4 as uuid } from "uuid"
+import IStampFactory from "../../domain/stamp/IStampFactory"
 import Stamp from "../../domain/stamp/Stamp"
 
-class StampFactory {
+class StampFactory implements IStampFactory {
   public create(
+    id: string,
     userId: string,
     roomId: string,
     topicId: number,
     timestamp: number,
   ): Stamp {
-    const id = uuid()
     const createdAt = new Date()
 
     return new Stamp(id, userId, roomId, topicId, createdAt, timestamp)

--- a/app/server/src/ioServer.ts
+++ b/app/server/src/ioServer.ts
@@ -226,6 +226,7 @@ const createSocketIOServer = async (
     socket.on("POST_STAMP", (received, callback) => {
       try {
         stampService.post({
+          id: received.id,
           userId,
           topicId: received.topicId,
         })

--- a/app/server/src/service/stamp/StampService.ts
+++ b/app/server/src/service/stamp/StampService.ts
@@ -16,7 +16,7 @@ class StampService {
     private readonly stampFactory: IStampFactory,
   ) {}
 
-  public async post({ userId, topicId }: PostStampCommand) {
+  public async post({ id, userId, topicId }: PostStampCommand) {
     const user = await UserService.findUserOrThrow(userId, this.userRepository)
     const roomId = user.roomId
 
@@ -26,7 +26,13 @@ class StampService {
     )
     const timestamp = room.calcTimestamp(topicId)
 
-    const stamp = this.stampFactory.create(userId, roomId, topicId, timestamp)
+    const stamp = this.stampFactory.create(
+      id,
+      userId,
+      roomId,
+      topicId,
+      timestamp,
+    )
     room.postStamp(stamp)
 
     this.stampDelivery.pushStamp(stamp)

--- a/app/server/src/service/stamp/commands.ts
+++ b/app/server/src/service/stamp/commands.ts
@@ -1,4 +1,5 @@
 export type PostStampCommand = {
+  id: string
   topicId: number
   userId: string
 }

--- a/app/shared/src/types/socketio.ts
+++ b/app/shared/src/types/socketio.ts
@@ -82,6 +82,7 @@ export type PubChatItemParam = ChatItemModel
 
 // POST_STAMP
 export type PostStampRequest = {
+  id: string
   topicId: number
 }
 export type PostStampResponse = SuccessResponse | ErrorResponse

--- a/doc/reference/sushi-chat-api.yaml
+++ b/doc/reference/sushi-chat-api.yaml
@@ -568,8 +568,14 @@ paths:
           schema:
             type: object
             properties:
+              id:
+                type: string
+                format: uuid
               topicId:
                 type: number
+            required:
+              - id
+              - topicId
           description: ""
       tags:
         - SocketIO


### PR DESCRIPTION
close #466 

## やったこと
スタンプのIDを、chatItemと同様にフロントで生成するように変更
- [doc] API Specを修正
- [shared] API型を修正
- [front] StampStoreを修正し、自分が送ったスタンプを省く処理を追加
- [server] stampのidをフロントから渡ってきたものを利用するように変更

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
~~**#556 のバグは未修正です**~~
永田が修正してくれた