### PR TITLE
トピックIDのずれを修正

### DIFF
--- a/app/front/pages/room/create.vue
+++ b/app/front/pages/room/create.vue
@@ -239,7 +239,7 @@ export default Vue.extend({
 
         const res = await this.$apiClient.post("/room", {
           title: this.roomName,
-          topics: sessions,
+          topics: sessions.map(({ title }) => ({ title })), // titleのみの配列に変換
           description: "hello, world",
         })
 


### PR DESCRIPTION
close #xxx

## やったこと
フロント側で意図せず、フロントで利用しているidをサーバに送ってしまっていたのが原因だったので修正した

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
