### PR TITLE
fix: ルーム作成時にdescriptionを指定できるようにする

### DIFF
--- a/app/front/pages/room/create.vue
+++ b/app/front/pages/room/create.vue
@@ -9,8 +9,16 @@
         placeholder="イベント名"
       />
     </section>
+    <section class="home-create__event-name">
+      <div class="home-create__event-name--title">2. イベントの説明</div>
+      <textarea
+        v-model="roomDescription"
+        class="home-create__event-name--input"
+        placeholder="イベントの説明"
+      />
+    </section>
     <section class="home-create__room">
-      <div class="home-create__room--title">2. セッションの登録</div>
+      <div class="home-create__room--title">3. セッションの登録</div>
       <div class="home-create__room__sessions">
         <div class="home-create__room__sessions__index">
           <div v-for="num in sessionList.length" :key="num">
@@ -119,6 +127,7 @@ import CreationCompletedModal from "@/components/Home/CreationCompletedModal.vue
 Vue.use(VModal)
 type DataType = {
   roomName: string
+  roomDescription: string
   sessionList: { title: string; id: number }[]
   isDragging: boolean
   MAX_TOPIC_LENGTH: number
@@ -140,6 +149,7 @@ export default Vue.extend({
   data(): DataType {
     return {
       roomName: "",
+      roomDescription: "",
       sessionList: [{ title: "", id: sessionId++ }],
       isDragging: false,
       MAX_TOPIC_LENGTH: 100,
@@ -240,7 +250,7 @@ export default Vue.extend({
         const res = await this.$apiClient.post("/room", {
           title: this.roomName,
           topics: sessions.map(({ title }) => ({ title })), // titleのみの配列に変換
-          description: "hello, world",
+          description: this.roomDescription,
         })
 
         if (res.result === "error") {


### PR DESCRIPTION
close #513 

## やったこと
ルーム作成画面にdescription入力欄が抜けていたので追加した。

## やっていないこと
文字数制限

## スクリーンショット
<img width="1532" alt="スクリーンショット 2021-11-28 23 18 29" src="https://user-images.githubusercontent.com/65712721/143771727-9031f8c1-bc39-4145-9802-befe5a723f81.png">
<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
