### PR TITLE
送信失敗時のUIと再送信処理を実装

### DIFF
--- a/app/front/assets/scss/common.scss
+++ b/app/front/assets/scss/common.scss
@@ -23,6 +23,10 @@ button {
   &:focus-visible {
     outline: auto;
   }
+
+  &:disabled {
+    cursor: default;
+  }
 }
 
 label {

--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -93,7 +93,6 @@
       &:disabled {
         color: rgba(204, 204, 204, 0.5);
         background: transparent;
-        cursor: default;
       }
     }
   }
@@ -338,7 +337,6 @@
       &:disabled {
         background: rgb(192, 192, 192);
         border-color: rgb(192, 192, 192);
-        cursor: default;
       }
     }
   }
@@ -700,9 +698,13 @@
           margin-left: 0.5rem;
           color: $text-gray;
 
-          &:hover {
+          &:hover:not(:disabled) {
             color: $text-gray;
             background-color: $placeholder-gray;
+          }
+
+          &:disabled {
+            color: $disabled-gray;
           }
 
           & > .icon {
@@ -739,6 +741,44 @@
           &.is-liked {
             color: white;
             transform: rotate(-20deg);
+          }
+        }
+      }
+
+      .error-label {
+        display: flex;
+        align-items: center;
+
+        & > .error-icon {
+          color: rgb(249, 69, 69);
+        }
+
+        & > .error-message {
+          @include text-size($size: "sm");
+          display: block;
+          margin-left: 0.5em;
+          line-height: 1.1;
+          color: rgb(249, 69, 69);
+        }
+
+        & > .retry-button {
+          display: flex;
+          margin-left: 0.5em;
+          width: 1.7em;
+          height: 1.7em;
+          padding: 0;
+          border-radius: 4px;
+          transition: all 0.2s;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+
+          &:hover:not(:disabled) {
+            background: rgba(249, 69, 69, 0.1);
+          }
+
+          & > svg {
+            color: rgb(249, 69, 69);
           }
         }
       }

--- a/app/front/components/ChatRoom.vue
+++ b/app/front/components/ChatRoom.vue
@@ -86,6 +86,7 @@ import TextArea from "@/components/TextArea.vue"
 import FavoriteButton from "@/components/FavoriteButton.vue"
 import exportText from "@/utils/textExports"
 import { ChatItemStore, TopicStore, PinnedChatItemsStore } from "~/store"
+import { ChatItemWithStatus } from "~/store/chatItems"
 
 // Data型
 type DataType = {
@@ -140,7 +141,7 @@ export default Vue.extend({
     },
     pinnedChatItem() {
       const chatItems = ChatItemStore.chatItems.filter(
-        (chatItemModel): chatItemModel is ChatItemModel =>
+        (chatItemModel): chatItemModel is ChatItemWithStatus =>
           chatItemModel.topicId === this.topicId,
       )
       const pinnedChatItems = PinnedChatItemsStore.pinnedChatItems

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -49,7 +49,6 @@ import {
   RoomModel,
   RoomState,
   StampModel,
-  ChatItemModel,
   PubUserCountParam,
   PubPinnedMessageParam,
 } from "sushi-chat-shared"
@@ -174,10 +173,10 @@ export default Vue.extend({
       this.$initSocket(UserItemStore.userItems.isAdmin)
 
       // SocketIOのコールバックの登録
-      this.$socket().on("PUB_CHAT_ITEM", (chatItem: ChatItemModel) => {
+      this.$socket().on("PUB_CHAT_ITEM", (chatItem) => {
         console.log(chatItem)
         // 自分が送信したChatItemであればupdate、他のユーザーが送信したchatItemであればaddを行う
-        ChatItemStore.addOrUpdate(chatItem)
+        ChatItemStore.addOrUpdate({ ...chatItem, status: "success" })
       })
       this.$socket().on("PUB_CHANGE_TOPIC_STATE", (res) => {
         // クリックしたTopicのStateを変える
@@ -259,7 +258,12 @@ export default Vue.extend({
               PinnedChatItemsStore.add(pinnedChatItem)
             }
           })
-          ChatItemStore.setChatItems(res.data.chatItems)
+          ChatItemStore.setChatItems(
+            res.data.chatItems.map((chatItem) => ({
+              ...chatItem,
+              status: "success",
+            })),
+          )
         },
       )
       this.isRoomEnter = true
@@ -277,7 +281,12 @@ export default Vue.extend({
             console.error(res.error)
             return
           }
-          ChatItemStore.setChatItems(res.data.chatItems)
+          ChatItemStore.setChatItems(
+            res.data.chatItems.map((chatItem) => ({
+              ...chatItem,
+              status: "success",
+            })),
+          )
           res.data.topicStates.forEach((topicState) => {
             TopicStateItemStore.change({
               key: topicState.topicId,

--- a/app/front/store/chatItems.ts
+++ b/app/front/store/chatItems.ts
@@ -1,9 +1,20 @@
 import { Module, VuexModule, Mutation, Action } from "vuex-module-decorators"
-import { PostChatItemRequest, ChatItemModel, ChatItemSenderType } from "sushi-chat-shared"
+import { ChatItemModel, ChatItemSenderType } from "sushi-chat-shared"
 import getUUID from "~/utils/getUUID"
 import { AuthStore, UserItemStore } from "~/store"
 import buildSocket from "~/utils/socketIO"
 import emitAsync from "~/utils/emitAsync"
+
+/**
+ * メッセージの通信状態
+ * - success: 送信成功 or サーバから配信されたメッセージ
+ * - failure: 送信失敗
+ * - loading: 送信中
+ */
+export type ChatItemStatus = "success" | "failure" | "loading"
+export type ChatItemWithStatus = ChatItemModel & {
+  status: ChatItemStatus
+}
 
 @Module({
   name: "chatItems",
@@ -11,24 +22,24 @@ import emitAsync from "~/utils/emitAsync"
   namespaced: true,
 })
 export default class ChatItems extends VuexModule {
-  private _chatItems: ChatItemModel[] = []
+  private _chatItems: ChatItemWithStatus[] = []
 
-  public get chatItems(): ChatItemModel[] {
+  public get chatItems(): ChatItemWithStatus[] {
     return this._chatItems
   }
 
   @Mutation
-  public add(chatItem: ChatItemModel) {
+  public add(chatItem: ChatItemWithStatus) {
     this._chatItems.push(chatItem)
   }
 
   @Mutation
-  public setChatItems(chatItems: ChatItemModel[]) {
+  public setChatItems(chatItems: ChatItemWithStatus[]) {
     this._chatItems = chatItems
   }
 
   @Mutation
-  public addList(chatItems: ChatItemModel[]) {
+  public addList(chatItems: ChatItemWithStatus[]) {
     if (chatItems.length === 0) {
       return
     }
@@ -36,9 +47,16 @@ export default class ChatItems extends VuexModule {
   }
 
   @Mutation
-  public update(chatItem: ChatItemModel) {
+  public update(chatItem: ChatItemWithStatus) {
     this._chatItems = this._chatItems.map((item) =>
       item.id === chatItem.id ? chatItem : item,
+    )
+  }
+
+  @Mutation
+  public updateStatus({ id, status }: { id: string; status: ChatItemStatus }) {
+    this._chatItems = this._chatItems.map((item) =>
+      item.id === id ? { ...item, status } : item,
     )
   }
 
@@ -49,7 +67,7 @@ export default class ChatItems extends VuexModule {
   }
 
   @Action({ rawError: true })
-  public addOrUpdate(chatItem: ChatItemModel) {
+  public addOrUpdate(chatItem: ChatItemWithStatus) {
     if (this._chatItems.find(({ id }) => id === chatItem.id)) {
       this.update(chatItem)
     } else {
@@ -67,20 +85,18 @@ export default class ChatItems extends VuexModule {
     topicId: number
     target?: ChatItemModel
   }) {
-    const params: PostChatItemRequest = {
-      id: getUUID(),
-      type: "message",
-      topicId,
-      content: text,
-      quoteId: target?.id,
-    }
-    const senderType: ChatItemSenderType = 
-      UserItemStore.userItems.isAdmin? "admin" : 
-      UserItemStore.userItems.speakerId === topicId? "speaker" :
-      "general"
+    const id = getUUID()
+
+    const senderType: ChatItemSenderType = UserItemStore.userItems.isAdmin
+      ? "admin"
+      : UserItemStore.userItems.speakerId === topicId
+      ? "speaker"
+      : "general"
+
     // ローカルに反映する
     this.add({
-      id: params.id,
+      id,
+      status: "loading",
       topicId,
       type: "message",
       senderType,
@@ -90,30 +106,30 @@ export default class ChatItems extends VuexModule {
       quote: target,
       timestamp: undefined,
     })
+
     // サーバーに送信する
     const socket = buildSocket(AuthStore.idToken)
     try {
-      await emitAsync(socket, "POST_CHAT_ITEM", params)
-      // TODO: 正しいタイムスタンプを設定する
+      await emitAsync(socket, "POST_CHAT_ITEM", {
+        id,
+        type: "message",
+        topicId,
+        content: text,
+        quoteId: target?.id,
+      })
+      console.log("send message: ", text)
     } catch (e) {
-      // ローカルで追加したchatItemを削除する
-      this.remove(params.id)
-      throw e
+      this.updateStatus({ id, status: "failure" })
     }
-    console.log("send message: ", text)
   }
 
   @Action({ rawError: true })
   public async postReaction({ message }: { message: ChatItemModel }) {
-    const params: PostChatItemRequest = {
-      id: getUUID(),
-      type: "reaction",
-      topicId: message.topicId,
-      quoteId: message.id,
-    }
+    const id = getUUID()
     // ローカルに反映する
     this.add({
-      id: params.id,
+      id,
+      status: "loading",
       topicId: message.topicId,
       type: "reaction",
       senderType: "general",
@@ -125,14 +141,16 @@ export default class ChatItems extends VuexModule {
     // サーバーに反映する
     const socket = buildSocket(AuthStore.idToken)
     try {
-      await emitAsync(socket, "POST_CHAT_ITEM", params)
-      // TODO: 正しいタイムスタンプを設定する
+      await emitAsync(socket, "POST_CHAT_ITEM", {
+        id,
+        type: "reaction",
+        topicId: message.topicId,
+        quoteId: message.id,
+      })
+      console.log("send reaction: ", message.content)
     } catch (e) {
-      // ローカルで追加したchatItemを削除する
-      this.remove(params.id)
-      throw e
+      this.updateStatus({ id, status: "failure" })
     }
-    console.log("send reaction: ", message.content)
   }
 
   @Action({ rawError: true })
@@ -145,20 +163,18 @@ export default class ChatItems extends VuexModule {
     topicId: number
     target?: ChatItemModel
   }) {
-    const params: PostChatItemRequest = {
-      id: getUUID(),
-      type: "question",
-      topicId,
-      content: text,
-      quoteId: target?.id,
-    }
-    const senderType: ChatItemSenderType = 
-      UserItemStore.userItems.isAdmin? "admin" : 
-      UserItemStore.userItems.speakerId === topicId? "speaker" :
-      "general"
+    const id = getUUID()
+
+    const senderType: ChatItemSenderType = UserItemStore.userItems.isAdmin
+      ? "admin"
+      : UserItemStore.userItems.speakerId === topicId
+      ? "speaker"
+      : "general"
+
     // ローカルに反映する
     this.add({
-      id: params.id,
+      id,
+      status: "loading",
       topicId,
       type: "question",
       senderType,
@@ -171,14 +187,17 @@ export default class ChatItems extends VuexModule {
     // サーバーに反映する
     const socket = buildSocket(AuthStore.idToken)
     try {
-      await emitAsync(socket, "POST_CHAT_ITEM", params)
-      // TODO: 正しいタイムスタンプを設定する
+      await emitAsync(socket, "POST_CHAT_ITEM", {
+        id,
+        type: "question",
+        topicId,
+        content: text,
+        quoteId: target?.id,
+      })
+      console.log("send question: ", text)
     } catch (e) {
-      // ローカルで追加したchatItemを削除する
-      this.remove(params.id)
-      throw e
+      this.updateStatus({ id, status: "failure" })
     }
-    console.log("send question: ", text)
   }
 
   @Action({ rawError: true })
@@ -191,20 +210,17 @@ export default class ChatItems extends VuexModule {
     topicId: number
     target: ChatItemModel
   }) {
-    const params: PostChatItemRequest = {
-      id: getUUID(),
-      type: "answer",
-      topicId,
-      quoteId: target.id,
-      content: text,
-    }
-    const senderType: ChatItemSenderType = 
-      UserItemStore.userItems.isAdmin? "admin" : 
-      UserItemStore.userItems.speakerId === topicId? "speaker" :
-      "general"
+    const id = getUUID()
+
+    const senderType: ChatItemSenderType = UserItemStore.userItems.isAdmin
+      ? "admin"
+      : UserItemStore.userItems.speakerId === topicId
+      ? "speaker"
+      : "general"
     // ローカルに反映する
     this.add({
-      id: params.id,
+      id,
+      status: "loading",
       topicId,
       type: "answer",
       senderType,
@@ -217,13 +233,28 @@ export default class ChatItems extends VuexModule {
     // サーバーに反映する
     const socket = buildSocket(AuthStore.idToken)
     try {
-      await emitAsync(socket, "POST_CHAT_ITEM", params)
-      // TODO: 正しいタイムスタンプを設定する
+      await emitAsync(socket, "POST_CHAT_ITEM", {
+        id,
+        type: "answer",
+        topicId,
+        quoteId: target.id,
+        content: text,
+      })
+      console.log("send answer: ", text)
     } catch (e) {
-      // ローカルで追加したchatItemを削除する
-      this.remove(params.id)
-      throw e
+      this.updateStatus({ id, status: "failure" })
     }
-    console.log("send answer: ", text)
+  }
+
+  @Action({ rawError: true })
+  public async retrySendChatItem({ chatItem }: { chatItem: ChatItemModel }) {
+    const socket = buildSocket(AuthStore.idToken)
+    this.updateStatus({ id: chatItem.id, status: "loading" })
+    try {
+      await emitAsync(socket, "POST_CHAT_ITEM", chatItem)
+      console.log("retry send chatItem: ", chatItem.content)
+    } catch (e) {
+      this.updateStatus({ id: chatItem.id, status: "failure" })
+    }
   }
 }


### PR DESCRIPTION
close #584 

## やったこと
- 送信中のUI表示
- 送信失敗時のエラー表示 & 再送信ボタンのUIを追加
- メッセージの再送信処理を実装


## やっていないこと
- リアクション・スタンプの送信中・エラー・再送信処理（失敗してもそこまで影響がないため放置）


## スクリーンショット
- 送信失敗
![image](https://user-images.githubusercontent.com/38308823/143774863-c35b81e5-de2c-459c-999c-6009b4c245e7.png)

- ローディング
![image](https://user-images.githubusercontent.com/38308823/143775013-c45372c7-a9da-4b87-8347-b70370c56df5.png)


<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
