### PR TITLE
ルーム作成画面のレスポンシブ

### DIFF
--- a/app/front/assets/scss/home/home.scss
+++ b/app/front/assets/scss/home/home.scss
@@ -131,7 +131,7 @@
         margin: 0 0.5rem 0 0;
         &--element {
           margin: 0 0 0.5rem 0;
-          padding: 0.92rem 0;
+          padding: 0.55rem 0;
         }
       }
       &__list {
@@ -147,6 +147,7 @@
             padding: 0 !important;
             @include white-text-box($expand: "true");
             input {
+              width: 100%;
               border: none;
               flex: 1;
               padding: 0;
@@ -156,7 +157,7 @@
             }
           }
           &--remove {
-            margin: 0.2rem;
+            margin: 0.2rem 0;
             @include material-icon-button(
               $size: "sm",
               $color: #f07b7b,
@@ -169,6 +170,7 @@
             }
           }
           &--sort {
+            margin: 0;
             cursor: grab !important;
             @include material-icon-button;
             &--dragging {

--- a/app/front/assets/scss/home/home.scss
+++ b/app/front/assets/scss/home/home.scss
@@ -125,12 +125,13 @@
       display: grid;
       margin: 1rem 0;
       grid-template-columns: auto 1fr;
+      align-items: center;
       &__index {
         grid-column: 1;
         margin: 0 0.5rem 0 0;
         &--element {
-          margin: 0.2rem 0 0.9em 0;
-          padding: 0.5rem 0;
+          margin: 0 0 0.5rem 0;
+          padding: 0.92rem 0;
         }
       }
       &__list {
@@ -138,7 +139,6 @@
         &--element {
           display: flex;
           align-items: center;
-          width: 85%;
           margin: 0 0 0.5rem 0;
           &--input {
             display: flex;
@@ -150,7 +150,6 @@
               border: none;
               flex: 1;
               padding: 0;
-              @include white-text-box($expand: "true");
               &:focus {
                 outline: none;
               }

--- a/app/front/assets/scss/home/home.scss
+++ b/app/front/assets/scss/home/home.scss
@@ -145,12 +145,12 @@
             flex: 1;
             margin: 0 0.5rem 0 0;
             padding: 0 !important;
-            @include white-text-box($expand: "true");
             input {
               width: 100%;
               border: none;
               flex: 1;
               padding: 0;
+              @include white-text-box($expand: "true");
               &:focus {
                 outline: none;
               }

--- a/app/front/assets/scss/home/variables.scss
+++ b/app/front/assets/scss/home/variables.scss
@@ -89,8 +89,8 @@
   $color: $text-gray,
   $border: "none"
 ) {
-  width: 36px;
-  height: 36px;
+  width: 24px;
+  height: 24px;
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/app/front/components/Home/Modal.vue
+++ b/app/front/components/Home/Modal.vue
@@ -40,7 +40,7 @@ export default Vue.extend({
   computed: {
     width() {
       if (DeviceStore.device === "smartphone") {
-        return "100%"
+        return "90%"
       } else {
         return "50%"
       }

--- a/app/front/pages/room/create.vue
+++ b/app/front/pages/room/create.vue
@@ -61,21 +61,23 @@
                   />
                   <button
                     type="button"
-                    class="home-create__room__sessions__list--element--remove"
                     :disabled="!canDeleteSessionInput"
                     @click="removeSession(idx)"
                   >
-                    <MinusCircleIcon size="1.2x"></MinusCircleIcon>
+                    <MinusCircleIcon
+                      class="home-create__room__sessions__list--element--remove"
+                    ></MinusCircleIcon>
                   </button>
                 </form>
                 <button
-                  class="home-create__room__sessions__list--element--sort"
                   :class="{
                     'home-create__room__sessions__list--element--sort--dragging':
                       isDragging === true,
                   }"
                 >
-                  <MenuIcon size="1.2x"></MenuIcon>
+                  <MenuIcon
+                    class="home-create__room__sessions__list--element--sort"
+                  ></MenuIcon>
                 </button>
               </div>
             </transition-group>


### PR DESCRIPTION
close #346 

## やったこと
- ボタンサイズのCSSが効いていないのを効かせた
- テキストボックスと高さを合わせる
- スマホ実機でも入れ替えボタンを画面内に入れる

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
