### PR TITLE
APIクライアントを修正

### DIFF
--- a/app/front/apiClient/index.ts
+++ b/app/front/apiClient/index.ts
@@ -1,5 +1,5 @@
 import { NuxtAxiosInstance } from "@nuxtjs/axios"
-import { RestApi, PathsWithMethod } from "sushi-chat-shared"
+import { RestApi, PathsWithMethod, EmptyRecord } from "sushi-chat-shared"
 
 type PathObject<
   Method extends "get" | "post" | "put",
@@ -8,6 +8,13 @@ type PathObject<
   pathname: Path
   params: RestApi<Method, Path>["params"]
 }
+
+type PathOrPathObj<
+  Method extends "get" | "post" | "put",
+  Path extends PathsWithMethod<Method>,
+> = Path extends `${string}:${string}`
+  ? PathObject<Method, Path>
+  : Path | PathObject<Method, Path>
 
 /**
  * PathObjectからパスを組み立てる関数
@@ -32,7 +39,6 @@ const pathBuilder = (path: {
  *  async asyncData({ app }) {
  *    const sampleResponse = await app.$apiClient.get(
  *      { pathname: "/room/:id/history", params: { id: "roomId" } },
- *      {},
  *    )
  *    if (sampleResponse.result === "success") {
  *      const rooms = sampleResponse.data
@@ -65,18 +71,17 @@ export default class Repository {
   /**
    * getリクエストを行う
    * @param path エンドポイントを表すPathObjectまたはパス文字列（パスパラメータ（`:xyz`）を含まない場合は直接文字列を指定可能）
-   * @param data 送信するデータ
+   * @param query クエリパラメータ
    * @returns レスポンス
    */
   public async get<Path extends PathsWithMethod<"get">>(
-    path: Path extends `${string}:${string}`
-      ? PathObject<"get", Path>
-      : Path | PathObject<"get", Path>,
-    data: RestApi<"get", Path>["request"],
+    ...[path, query]: RestApi<"get", Path>["query"] extends EmptyRecord
+      ? [path: PathOrPathObj<"get", Path>]
+      : [path: PathOrPathObj<"get", Path>, query: RestApi<"get", Path>["query"]]
   ) {
     return await this.nuxtAxios.$get<RestApi<"get", Path>["response"]>(
       typeof path === "string" ? path : pathBuilder(path),
-      { data },
+      { params: query },
     )
   }
 
@@ -87,14 +92,31 @@ export default class Repository {
    * @returns レスポンス
    */
   public async post<Path extends PathsWithMethod<"post">>(
-    path: Path extends `${string}:${string}`
-      ? PathObject<"post", Path>
-      : Path | PathObject<"post", Path>,
-    data: RestApi<"post", Path>["request"],
+    ...[path, body, query]: RestApi<"post", Path>["request"] extends EmptyRecord
+      ? RestApi<"post", Path>["query"] extends EmptyRecord
+        ? [path: PathOrPathObj<"post", Path>]
+        : [
+            path: PathOrPathObj<"post", Path>,
+            body: RestApi<"post", Path>["request"],
+            query: RestApi<"post", Path>["query"],
+          ]
+      : RestApi<"post", Path>["query"] extends EmptyRecord
+      ? [
+          path: PathOrPathObj<"post", Path>,
+          body: RestApi<"post", Path>["request"],
+        ]
+      : [
+          path: PathOrPathObj<"post", Path>,
+          body: RestApi<"post", Path>["request"],
+          query: RestApi<"post", Path>["query"],
+        ]
   ) {
     return await this.nuxtAxios.$post<RestApi<"post", Path>["response"]>(
       typeof path === "string" ? path : pathBuilder(path),
-      data,
+      body,
+      {
+        params: query,
+      },
     )
   }
 
@@ -105,14 +127,31 @@ export default class Repository {
    * @returns レスポンス
    */
   public async put<Path extends PathsWithMethod<"put">>(
-    path: Path extends `${string}:${string}`
-      ? PathObject<"put", Path>
-      : Path | PathObject<"put", Path>,
-    data: RestApi<"put", Path>["request"],
+    ...[path, data, query]: RestApi<"put", Path>["request"] extends EmptyRecord
+      ? RestApi<"put", Path>["query"] extends EmptyRecord
+        ? [path: PathOrPathObj<"put", Path>]
+        : [
+            path: PathOrPathObj<"put", Path>,
+            body: RestApi<"put", Path>["request"],
+            query: RestApi<"put", Path>["query"],
+          ]
+      : RestApi<"put", Path>["query"] extends EmptyRecord
+      ? [
+          path: PathOrPathObj<"put", Path>,
+          body: RestApi<"put", Path>["request"],
+        ]
+      : [
+          path: PathOrPathObj<"put", Path>,
+          body: RestApi<"put", Path>["request"],
+          query: RestApi<"put", Path>["query"],
+        ]
   ) {
     return await this.nuxtAxios.$put<RestApi<"put", Path>["response"]>(
       typeof path === "string" ? path : pathBuilder(path),
       data,
+      {
+        params: query,
+      },
     )
   }
 }

--- a/app/front/pages/home.vue
+++ b/app/front/pages/home.vue
@@ -126,7 +126,8 @@ export default Vue.extend({
   layout: "home",
   middleware: "privateRoute",
   async asyncData({ app }): Promise<AsyncDataType> {
-    const response = await app.$apiClient.get("/room", {})
+    const response = await app.$apiClient.get("/room")
+
     if (response.result === "success") {
       const rooms = response.data
       const ongoingRooms = rooms.filter((room) => room.state === "ongoing")
@@ -174,13 +175,10 @@ export default Vue.extend({
       }
       try {
         console.log(id)
-        const response = await this.$apiClient.put(
-          {
-            pathname: "/room/:id/archive",
-            params: { id },
-          },
-          {},
-        )
+        const response = await this.$apiClient.put({
+          pathname: "/room/:id/archive",
+          params: { id },
+        })
 
         if (response.result === "success") {
           this.finishedRooms = this.finishedRooms.filter(

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -142,13 +142,10 @@ export default Vue.extend({
     async checkStatusAndAction() {
       // ルーム情報取得・status更新
       const res = await this.$apiClient
-        .get(
-          {
-            pathname: "/room/:id",
-            params: { id: this.room.id },
-          },
-          {},
-        )
+        .get({
+          pathname: "/room/:id",
+          params: { id: this.room.id },
+        })
         .catch((e) => {
           throw new Error(e)
         })
@@ -321,13 +318,10 @@ export default Vue.extend({
     startRoom() {
       // TODO: ルームの状態をindex、またはvuexでもつ
       this.$apiClient
-        .put(
-          {
-            pathname: "/room/:id/start",
-            params: { id: this.room.id },
-          },
-          {},
-        )
+        .put({
+          pathname: "/room/:id/start",
+          params: { id: this.room.id },
+        })
         .then(() => {
           this.adminEnterRoom()
           this.roomState = "ongoing"

--- a/app/front/pages/invited.vue
+++ b/app/front/pages/invited.vue
@@ -39,13 +39,10 @@ export default Vue.extend({
     InviteSuccess,
   },
   async asyncData({ app, query }) {
-    const res = await app.$apiClient.get(
-      {
-        pathname: "/room/:id",
-        params: { id: query.roomId as string },
-      },
-      {},
-    )
+    const res = await app.$apiClient.get({
+      pathname: "/room/:id",
+      params: { id: query.roomId as string },
+    })
     if (res.result === "error") {
       throw new Error("ルーム情報なし")
     }
@@ -70,9 +67,14 @@ export default Vue.extend({
   methods: {
     async regiaterAdmin() {
       const res = await this.$apiClient.post(
-        // @ts-ignore
-        `/room/${this.roomId}/invited?admin_invite_key=${this.adminInviteKey}`,
+        {
+          pathname: `/room/:id/invited`,
+          params: { id: this.roomId },
+        },
         {},
+        {
+          admin_invite_key: this.adminInviteKey,
+        },
       )
       if (res.result === "error") {
         window.alert("処理に失敗しました")

--- a/app/server/src/expressRoute.ts
+++ b/app/server/src/expressRoute.ts
@@ -16,7 +16,7 @@ export type Routes = Omit<ExpressCore, "get" | "post" | "put"> & {
       req: express.Request<
         RestApi<"get", Path>["params"],
         RestApi<"get", Path>["response"],
-        RestApi<"get", Path>["request"],
+        unknown,
         RestApi<"get", Path>["query"]
       >,
       res: express.Response<RestApi<"get", Path>["response"]>,

--- a/app/server/src/rest.ts
+++ b/app/server/src/rest.ts
@@ -120,6 +120,7 @@ export const restSetup = (
   adminRouter.get("/room", async (req, res) => {
     try {
       const rooms = await adminService.getManagedRooms({
+        // @ts-ignore bodyをadminIdの受け渡しに利用しているため
         adminId: req.body.adminId,
       })
 

--- a/app/shared/src/types/rest.ts
+++ b/app/shared/src/types/rest.ts
@@ -8,7 +8,6 @@ export type RestApiDefinition = {
     methods: {
       get: {
         query: Empty
-        request: Empty
         response: "ok"
       }
     }
@@ -18,7 +17,6 @@ export type RestApiDefinition = {
     methods: {
       get: {
         query: Empty
-        request: Empty
         response: SuccessResponse<RoomModel[]> | ErrorResponse
       }
       post: {
@@ -41,7 +39,6 @@ export type RestApiDefinition = {
     methods: {
       get: {
         query: Empty
-        request: Empty
         response: SuccessResponse<RoomModel> | ErrorResponse
       }
     }
@@ -65,7 +62,6 @@ export type RestApiDefinition = {
     methods: {
       get: {
         query: Empty
-        request: Empty
         response:
           | SuccessResponse<{
               chatItems: ChatItemModel[]
@@ -109,11 +105,15 @@ export type GeneralRestApiTypes = {
   [path: string]: {
     params: Record<string, unknown>
     methods: {
-      [K in "get" | "post" | "put"]?: {
+      [K in "post" | "put"]?: {
         query: Record<string, unknown>
         request: unknown
         response: unknown
       }
+    }
+    get?: {
+      query: Record<string, unknown>
+      response: unknown
     }
   }
 }
@@ -144,7 +144,6 @@ export type RestApi<
 > = Method extends "get"
   ? Path extends GetMethodPath
     ? {
-        request: RestApiDefinition[Path]["methods"]["get"]["request"]
         response: RestApiDefinition[Path]["methods"]["get"]["response"]
         params: RestApiDefinition[Path]["params"]
         query: RestApiDefinition[Path]["methods"]["get"]["query"]


### PR DESCRIPTION
close #560 

## やったこと
- APIクライアントでurl queryを指定できないケースがあったので、url queryを指定できるように変更
- API定義でgetメソッドにrequest bodyを指定できる仕様にしていたが、getメソッドでrequest bodyは使わない方が良いので削除。伴ってフロントのAPIクライアントも修正

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
