### PR TITLE
ルームアクセス時に一旦未開始の時の画面が現れるのを回避

### DIFF
--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -2,14 +2,14 @@
   <div class="container page">
     <main>
       <SelectIconModal
-        v-if="isRoomStarted && !isAdmin && !isRoomEnter"
+        v-if="loadingFinished && isRoomStarted && !isAdmin && !isRoomEnter"
         :title="room.title"
         :description="room.description"
         @click-icon="clickIcon"
         @hide-modal="hide"
       />
       <NotStarted
-        v-if="!isRoomStarted && !isAdmin"
+        v-if="loadingFinished && !isRoomStarted && !isAdmin"
         :title="room.title"
         :description="room.description"
         @check-status-and-action="checkStatusAndAction"
@@ -117,6 +117,9 @@ export default Vue.extend({
     },
     showAdminTool(): boolean {
       return this.isAdmin && this.room.adminInviteKey != null
+    },
+    loadingFinished(): boolean {
+      return Object.keys(this.room).length > 1
     },
   },
   created() {


### PR DESCRIPTION

close #462

## やったこと

roomオブジェクトが空（=ローディングが終わっていない）ときに、isRoomStartedがfalseになってしまう。
ので、そのチェックをした。

## やっていないこと

真っ白ダサいけど放置しちゃった、

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など

別案1 fetch終わったらフラグを立てる
なんかスマートじゃなくてやめた。

別案2 asyncDataを使う
問題は、同じfetchをボタンを押してできるようにしたいこと。methodsはasyncDataでは使えないので、二重実装を避けるにはここだけ別ファイルに切り出すか(いやだ)、ボタンを押したら画面全体がリロードされるようにする必要がある(なんかイケてない)
