### PR TITLE
fix: ルーム作成画面で日本語変換中にBackspaceをクリックした場合にカラムが消えてしまう

### DIFF
--- a/app/front/pages/room/create.vue
+++ b/app/front/pages/room/create.vue
@@ -54,10 +54,15 @@
                       )
                     "
                     @keydown.delete="
-                      if (sessionList[idx].title.length === 0) {
+                      if (
+                        sessionList[idx].title.length === 0 &&
+                        composing == false
+                      ) {
                         removeSessionAndMoveFocus($event, idx, 'up')
                       }
                     "
+                    @compositionstart="composing = true"
+                    @compositionend="composing = false"
                   />
                   <button
                     type="button"
@@ -122,6 +127,7 @@ type DataType = {
   sessionList: { title: string; id: number }[]
   isDragging: boolean
   MAX_TOPIC_LENGTH: number
+  composing: boolean
 }
 
 let sessionId = 0
@@ -143,6 +149,7 @@ export default Vue.extend({
       sessionList: [{ title: "", id: sessionId++ }],
       isDragging: false,
       MAX_TOPIC_LENGTH: 100,
+      composing: false,
     }
   },
   computed: {


### PR DESCRIPTION
close #543 

## やったこと
ルーム作成画面で日本語変換中にBackspaceをクリックした場合にカラムが消えてしまうバグを修正
<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
https://gotohayato.com/content/496/
