### PR TITLE
プレビュー用のドメインからのCORSを許可 

### DIFF
--- a/app/server/src/app.ts
+++ b/app/server/src/app.ts
@@ -14,6 +14,7 @@ import StampFactory from "./infra/factory/StampFactory"
 import AdminService from "./service/admin/AdminService"
 import AdminAuth from "./infra/auth/AdminAuth"
 import cors from "cors"
+import { CORS_OPTION } from "./utils/http"
 
 const app = express()
 const httpServer = createServer(app)
@@ -65,11 +66,7 @@ httpServer.listen(PORT, () => {
 })
 
 // ref: https://www.npmjs.com/package/cors#configuring-cors
-const corsOption = {
-  origin: process.env.CORS_ORIGIN ?? "http://localhost:3000",
-  optionsSuccessStatus: 200,
-}
-const myCors = () => cors(corsOption)
+const myCors = () => cors(CORS_OPTION)
 // NOTE: genericsでstringを指定しないと、オーバーロードがマッチしなくて型エラーが起こる
 app.options<string>("*", myCors())
 app.use(myCors())

--- a/app/server/src/ioServer.ts
+++ b/app/server/src/ioServer.ts
@@ -28,6 +28,7 @@ import { DefaultEventsMap } from "socket.io/dist/typed-events"
 import IStampFactory from "./domain/stamp/IStampFactory"
 import IAdminAuth from "./domain/admin/IAdminAuth"
 import AdminAuth from "./infra/auth/AdminAuth"
+import { CORS_OPTION } from "./utils/http"
 
 export class GlobalSocket extends Server<
   DefaultEventsMap,
@@ -51,7 +52,7 @@ const createSocketIOServer = async (
 ) => {
   const io = new GlobalSocket(httpServer, {
     cors: {
-      origin: process.env.CORS_ORIGIN ?? "http://localhost:3000",
+      ...CORS_OPTION,
       methods: ["GET", "POST"],
       credentials: true,
     },

--- a/app/server/src/utils/http.ts
+++ b/app/server/src/utils/http.ts
@@ -1,0 +1,7 @@
+export const CORS_OPTION = {
+  origin: [
+    process.env.CORS_ORIGIN ?? "http://localhost:3000",
+    new RegExp(process.env.CORS_ORIGIN_PREVIEW ?? "", "i"),
+  ],
+  optionsSuccessStatus: 200,
+}


### PR DESCRIPTION
close #628 

## やったこと
- 既存の`www.sushi-chat.com`の他に、プレビュー用のvercelのドメインからのCORSを正規表現でチェックして許可するようにした。

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
