### PR TITLE
fix: ChatItemが1行の時padding-bottomが大きくなる

### DIFF
--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -628,7 +628,6 @@
   .reaction {
     position: relative;
     width: 100%;
-    min-height: 5rem;
     flex-grow: 1;
     flex-shrink: 0;
     padding: 0em 0.8em 0.35em;


### PR DESCRIPTION
close #641 

## やったこと
ChatItemが1行のときにpadding-bottomが大きくなってしまっていたので直した。

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
