### PR TITLE
[fix]管理者の入室時にピン留めアイテムを取得

### DIFF
--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -254,6 +254,12 @@ export default Vue.extend({
             console.error(res.error)
             return
           }
+          ChatItemStore.setChatItems(
+            res.data.chatItems.map((chatItem) => ({
+              ...chatItem,
+              status: "success",
+            })),
+          )
           res.data.topicStates.forEach((topicState) => {
             TopicStateItemStore.change({
               key: topicState.topicId,
@@ -265,12 +271,6 @@ export default Vue.extend({
               PinnedChatItemsStore.add(pinnedChatItem)
             }
           })
-          ChatItemStore.setChatItems(
-            res.data.chatItems.map((chatItem) => ({
-              ...chatItem,
-              status: "success",
-            })),
-          )
         },
       )
       this.isRoomEnter = true
@@ -299,6 +299,11 @@ export default Vue.extend({
               key: topicState.topicId,
               state: topicState.state,
             })
+          })
+          res.data.pinnedChatItemIds.forEach((pinnedChatItem) => {
+            if (pinnedChatItem) {
+              PinnedChatItemsStore.add(pinnedChatItem)
+            }
           })
           this.activeUserCount = res.data.activeUserCount
         },


### PR DESCRIPTION
close #632 

## やったこと
- 管理者で入室時にピン留めアイテムを取得する
- 管理者、ユーザーの入室時の操作の共通化

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
