### PR TITLE
スマホで表示されていなかったアイコンを表示

### DIFF
--- a/app/front/components/ChatRoom.vue
+++ b/app/front/components/ChatRoom.vue
@@ -37,8 +37,8 @@
         </transition-group>
         <div v-if="showGraph" class="graph-wrapper">
           <div class="graph-action-area" style="text-align: end">
-            <button>
-              <span class="close-button" @click="showGraph = false">
+            <button @click="showGraph = false">
+              <span class="close-button">
                 <XIcon></XIcon>
               </span>
             </button>

--- a/app/front/components/ChatRoom.vue
+++ b/app/front/components/ChatRoom.vue
@@ -37,8 +37,10 @@
         </transition-group>
         <div v-if="showGraph" class="graph-wrapper">
           <div class="graph-action-area" style="text-align: end">
-            <button class="close-button" @click="showGraph = false">
-              <XIcon></XIcon>
+            <button>
+              <span class="close-button" @click="showGraph = false">
+                <XIcon></XIcon>
+              </span>
             </button>
           </div>
           <AnalysisGraph :topic-title="topic.title" :topic-id="topicId" />

--- a/app/front/components/TopicHeader.vue
+++ b/app/front/components/TopicHeader.vue
@@ -10,12 +10,14 @@
         #<span style="font-size: 80%">{{ topicIndex }}</span>
       </div>
       <div class="title">{{ title }}</div>
-      <button
-        class="more-button"
-        aria-label="メニューを開閉する"
-        @click="isOpenDetails = !isOpenDetails"
-      >
-        <MoreVerticalIcon aria-hidden="true"></MoreVerticalIcon>
+      <button>
+        <span
+          class="more-button"
+          aria-label="メニューを開閉する"
+          @click="isOpenDetails = !isOpenDetails"
+        >
+          <MoreVerticalIcon aria-hidden="true"></MoreVerticalIcon>
+        </span>
       </button>
     </div>
     <div v-if="isOpenDetails" class="topic-header__details">
@@ -56,14 +58,16 @@
       >
         {{ pinnedChatItemContent }}
       </button>
-      <button
-        v-show="isAdmin || isSpeaker"
-        class="topic-header__bookmark--close-icon"
-        aria-label="ピン留め解除"
-        title="ピン留め解除"
-        @click="removePinnedMessage"
-      >
-        <XCircleIcon size="1.2x" aria-hidden="true"></XCircleIcon>
+      <button>
+        <span
+          v-show="isAdmin || isSpeaker"
+          class="topic-header__bookmark--close-icon"
+          aria-label="ピン留め解除"
+          title="ピン留め解除"
+          @click="removePinnedMessage"
+        >
+          <XCircleIcon size="1.2x" aria-hidden="true"></XCircleIcon>
+        </span>
       </button>
     </div>
   </div>

--- a/app/front/components/TopicHeader.vue
+++ b/app/front/components/TopicHeader.vue
@@ -10,12 +10,11 @@
         #<span style="font-size: 80%">{{ topicIndex }}</span>
       </div>
       <div class="title">{{ title }}</div>
-      <button>
-        <span
-          class="more-button"
-          aria-label="メニューを開閉する"
-          @click="isOpenDetails = !isOpenDetails"
-        >
+      <button
+        aria-label="メニューを開閉する"
+        @click="isOpenDetails = !isOpenDetails"
+      >
+        <span class="more-button">
           <MoreVerticalIcon aria-hidden="true"></MoreVerticalIcon>
         </span>
       </button>
@@ -58,14 +57,13 @@
       >
         {{ pinnedChatItemContent }}
       </button>
-      <button>
-        <span
-          v-show="isAdmin || isSpeaker"
-          class="topic-header__bookmark--close-icon"
-          aria-label="ピン留め解除"
-          title="ピン留め解除"
-          @click="removePinnedMessage"
-        >
+      <button
+        v-show="isAdmin || isSpeaker"
+        aria-label="ピン留め解除"
+        title="ピン留め解除"
+        @click="removePinnedMessage"
+      >
+        <span class="topic-header__bookmark--close-icon">
           <XCircleIcon size="1.2x" aria-hidden="true"></XCircleIcon>
         </span>
       </button>


### PR DESCRIPTION
close #639 

## やったこと
スマホ版(実機)でみれていなかったボタン
- 3点リーダー
- ピン留め削除
を表示した

スマホ版でvue-feather-iconsを使用している箇所が全て表示されているか確認した(chrome)

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
