### PR TITLE
スピーカー選択欄の幅を入るようにした

### DIFF
--- a/app/front/assets/scss/sushiselect.scss
+++ b/app/front/assets/scss/sushiselect.scss
@@ -93,6 +93,7 @@
       width: 100%;
       max-width: 400px;
       margin-bottom: 50px;
+      border-radius: 4px;
       background: white;
       & > .select-speaker {
         -webkit-appearance: none;
@@ -102,7 +103,6 @@
         padding: 10px;
         padding-right: 2.5em;
         border: 1px solid transparent;
-        border-radius: 10px;
         outline: none;
         cursor: pointer;
         @include text-size("normal");

--- a/app/front/assets/scss/sushiselect.scss
+++ b/app/front/assets/scss/sushiselect.scss
@@ -90,8 +90,10 @@
     }
     &--speaker {
       position: relative;
-      width: 400px;
+      width: 100%;
+      max-width: 400px;
       margin-bottom: 50px;
+      background: white;
       & > .select-speaker {
         -webkit-appearance: none;
         appearance: none;

--- a/app/front/assets/scss/sushiselect.scss
+++ b/app/front/assets/scss/sushiselect.scss
@@ -93,8 +93,6 @@
       width: 100%;
       max-width: 400px;
       margin-bottom: 50px;
-      border-radius: 4px;
-      background: white;
       & > .select-speaker {
         -webkit-appearance: none;
         appearance: none;
@@ -102,14 +100,12 @@
         width: 100%;
         padding: 10px;
         padding-right: 2.5em;
-        border: 1px solid transparent;
+        border: none;
+        border-radius: 4px;
+        background: white;
         outline: none;
         cursor: pointer;
         @include text-size("normal");
-
-        &:focus-visible {
-          border-color: rgb(214, 214, 214);
-        }
       }
 
       & > .select-icon {


### PR DESCRIPTION
close #633 

## やったこと
- 背景白く
- `width: 100%` にし、`max-width: 400px` を設定

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
