### PR TITLE
終了時にアーカイブを取得

### DIFF
--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -103,7 +103,7 @@ export default Vue.extend({
   },
   computed: {
     isRoomStarted(): boolean {
-      return this.room.state === "ongoing"
+      return this.room.state === "ongoing" || this.room.state === "finished"
     },
     isAdmin(): boolean {
       return UserItemStore.userItems.isAdmin
@@ -162,19 +162,42 @@ export default Vue.extend({
       this.roomState = res.data.state
       TopicStore.set(res.data.topics)
 
-      // 開催中の時
       if (this.room.state === "ongoing") {
+        // 開催中
         if (this.isAdmin) {
           this.adminEnterRoom()
         } else {
           // ユーザーの入室
           this.$modal.show("sushi-modal")
         }
+      } else if (this.room.state === "finished") {
+        // 終了時。すべてのトピックが閉じたルームのアーカイブが閲覧できる。
+        const history = await this.$apiClient
+          .get({
+            pathname: "/room/:id/history",
+            params: { id: this.room.id },
+          })
+          .catch((e) => {
+            throw new Error(e)
+          })
+        if (history.result === "error") {
+          console.error(history.error)
+          return
+        }
+        // 入室
+        ChatItemStore.setChatItems(
+          history.data.chatItems.map((chatItem) => ({
+            ...chatItem,
+            status: "success",
+          })),
+        )
+        history.data.pinnedChatItemIds.forEach((pinnedChatItem) => {
+          if (pinnedChatItem) {
+            PinnedChatItemsStore.add(pinnedChatItem)
+          }
+        })
+        this.isRoomEnter = true
       }
-      if (this.room.state === "finished") {
-        // 本当はRESTでアーカイブデータを取ってきて表示する
-      }
-      // NOTE: もしかして：archivedも返ってくる？
     },
     // socket.ioのセットアップ。配信を受け取る
     async socketSetUp() {


### PR DESCRIPTION
close #640 

## やったこと
- ルーム終了時にRESTAPIを叩く
- トークの履歴と、ピン留めアイテムのみ取得(コメントはできない)

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
