### PR TITLE
ルーム一覧取得のDBコネクション枯渇問題を暫定対応していたのを修正

### DIFF
--- a/app/server/src/__test__/chat.ts
+++ b/app/server/src/__test__/chat.ts
@@ -204,7 +204,7 @@ describe("機能テスト", () => {
           client
             .post("/room")
             .send({
-              title: `傘増し用ルーム${n + 1}`,
+              title: `かさ増し用ルーム${n + 1}`,
               topics: [{ title: "トピック" }],
               description: "ルームの説明",
             })

--- a/app/server/src/__test__/chat.ts
+++ b/app/server/src/__test__/chat.ts
@@ -196,14 +196,30 @@ describe("機能テスト", () => {
   })
 
   describe("room一覧取得", () => {
+    // NOTE: ルームがコネクションプールの上限数以上ある時に怒るバグが存在したため、それが起こらないことを保証するために
+    //  たくさんルームを作る
+    beforeAll(async () => {
+      await Promise.all(
+        ArrayRange(10).map((n) =>
+          client
+            .post("/room")
+            .send({
+              title: `傘増し用ルーム${n + 1}`,
+              topics: [{ title: "トピック" }],
+              description: "ルームの説明",
+            })
+            .set("Authorization", "Bearer Token"),
+        ),
+      )
+    })
+
     test("正常系_管理者がroom一覧を取得", async () => {
       const res = await client.get("/room").set("Authorization", "Bearer token")
 
       expect(res.statusCode).toBe(200)
-      expect(res.body).toStrictEqual<SuccessResponse<RoomModel[]>>({
-        result: "success",
-        data: [roomData],
-      })
+      expect(res.body.result).toBe("success")
+      // 新しい順に取得されるので、ダミーでないデータは最後に来る
+      expect(res.body.data[res.body.data.length - 1]).toStrictEqual(roomData)
     })
   })
 

--- a/app/server/src/domain/admin/IAdminRepository.ts
+++ b/app/server/src/domain/admin/IAdminRepository.ts
@@ -1,9 +1,10 @@
 import Admin from "./admin"
+import { PoolClient } from "pg"
 
 interface IAdminRepository {
   createIfNotExist(admin: Admin): void
   find(adminId: string): Promise<Admin | null>
-  selectIdsByRoomId(roomId: string): Promise<string[]>
+  selectIdsByRoomId(roomId: string, pgClient: PoolClient): Promise<string[]>
 }
 
 export default IAdminRepository

--- a/app/server/src/domain/admin/IAdminRepository.ts
+++ b/app/server/src/domain/admin/IAdminRepository.ts
@@ -5,6 +5,10 @@ interface IAdminRepository {
   createIfNotExist(admin: Admin): void
   find(adminId: string): Promise<Admin | null>
   selectIdsByRoomId(roomId: string, pgClient: PoolClient): Promise<string[]>
+  selectIdsByRoomIds(
+    roomIds: string[],
+    pgClient?: PoolClient, // TODO: remove this arg to avoid appearing of implementation detail in interface
+  ): Promise<Record<string, string[]>> // adminIds per room
 }
 
 export default IAdminRepository

--- a/app/server/src/domain/chatItem/IChatItemRepository.ts
+++ b/app/server/src/domain/chatItem/IChatItemRepository.ts
@@ -12,6 +12,10 @@ interface IChatItemRepository {
   saveAnswer(answer: Answer): void
   find(chatItemId: string): Promise<ChatItem | null>
   selectByRoomId(roomId: string, pgClient: PoolClient): Promise<ChatItem[]>
+  selectByRoomIds(
+    roomIds: string[],
+    pgClient?: PoolClient, // TODO: remove this arg to avoid appearing of implementation detail in interface
+  ): Promise<Record<string, ChatItem[]>> // chatItems per room
   pinChatItem(chatItem: ChatItem): void
 }
 

--- a/app/server/src/domain/chatItem/IChatItemRepository.ts
+++ b/app/server/src/domain/chatItem/IChatItemRepository.ts
@@ -3,6 +3,7 @@ import Reaction from "./Reaction"
 import Question from "./Question"
 import Answer from "./Answer"
 import ChatItem from "./ChatItem"
+import { PoolClient } from "pg"
 
 interface IChatItemRepository {
   saveMessage(message: Message): void
@@ -10,7 +11,7 @@ interface IChatItemRepository {
   saveQuestion(question: Question): void
   saveAnswer(answer: Answer): void
   find(chatItemId: string): Promise<ChatItem | null>
-  selectByRoomId(roomId: string): Promise<ChatItem[]>
+  selectByRoomId(roomId: string, pgClient: PoolClient): Promise<ChatItem[]>
   pinChatItem(chatItem: ChatItem): void
 }
 

--- a/app/server/src/domain/room/IRoomRepository.ts
+++ b/app/server/src/domain/room/IRoomRepository.ts
@@ -2,6 +2,7 @@ import RoomClass from "./Room"
 
 interface IRoomRepository {
   find(roomId: string): Promise<RoomClass | null>
+  findRooms(roomId: string[]): Promise<RoomClass[]>
   build(room: RoomClass): void
   update(room: RoomClass): void
 }

--- a/app/server/src/domain/stamp/IStampRepository.ts
+++ b/app/server/src/domain/stamp/IStampRepository.ts
@@ -1,9 +1,10 @@
 import Stamp from "./Stamp"
+import { PoolClient } from "pg"
 
 interface IStampRepository {
   store(stamp: Stamp): void
   count(roomId: string, topicId?: number, userId?: string): Promise<number>
-  selectByRoomId(roomId: string): Promise<Stamp[]>
+  selectByRoomId(roomId: string, pgClient: PoolClient): Promise<Stamp[]>
 }
 
 export default IStampRepository

--- a/app/server/src/domain/stamp/IStampRepository.ts
+++ b/app/server/src/domain/stamp/IStampRepository.ts
@@ -5,6 +5,10 @@ interface IStampRepository {
   store(stamp: Stamp): void
   count(roomId: string, topicId?: number, userId?: string): Promise<number>
   selectByRoomId(roomId: string, pgClient: PoolClient): Promise<Stamp[]>
+  selectByRoomIds(
+    roomIds: string[],
+    pgClient?: PoolClient, // TODO: remove this arg to avoid appearing of implementation detail in interface
+  ): Promise<Record<string, Stamp[]>> // stamps per room
 }
 
 export default IStampRepository

--- a/app/server/src/domain/user/IUserRepository.ts
+++ b/app/server/src/domain/user/IUserRepository.ts
@@ -1,9 +1,10 @@
 import User from "./User"
+import { PoolClient } from "pg"
 
 interface IUserRepository {
   create(user: User): void
   find(userId: string): Promise<User | null>
-  selectByRoomId(roomId: string): Promise<User[]>
+  selectByRoomId(roomId: string, pgClient: PoolClient): Promise<User[]>
   leaveRoom(user: User): void
 }
 

--- a/app/server/src/domain/user/IUserRepository.ts
+++ b/app/server/src/domain/user/IUserRepository.ts
@@ -5,6 +5,10 @@ interface IUserRepository {
   create(user: User): void
   find(userId: string): Promise<User | null>
   selectByRoomId(roomId: string, pgClient: PoolClient): Promise<User[]>
+  selectByRoomIds(
+    roomIds: string[],
+    pgClient?: PoolClient, // TODO: remove this arg to avoid appearing of implementation detail in interface
+  ): Promise<Record<string, User[]>> // users per room
   leaveRoom(user: User): void
 }
 

--- a/app/server/src/infra/repository/User/EphemeralUserRepository.ts
+++ b/app/server/src/infra/repository/User/EphemeralUserRepository.ts
@@ -21,6 +21,15 @@ class EphemeralUserRepository implements IUserRepository {
   public leaveRoom(user: User): void {
     this.users = this.users.filter((u) => u.id !== user.id)
   }
+
+  public selectByRoomIds(roomIds: string[]): Promise<Record<string, User[]>> {
+    return Promise.resolve(
+      roomIds.reduce<Record<string, User[]>>((acc, cur) => {
+        acc[cur] = this.users.filter((u) => u.roomId === cur)
+        return acc
+      }, {}),
+    )
+  }
 }
 
 export default EphemeralUserRepository

--- a/app/server/src/infra/repository/User/UserRepository.ts
+++ b/app/server/src/infra/repository/User/UserRepository.ts
@@ -1,6 +1,7 @@
 import IUserRepository from "../../../domain/user/IUserRepository"
 import User from "../../../domain/user/User"
 import PGPool from "../PGPool"
+import { Pool, PoolClient } from "pg"
 
 class UserRepository implements IUserRepository {
   constructor(private readonly pgPool: PGPool) {}
@@ -66,9 +67,10 @@ class UserRepository implements IUserRepository {
     }
   }
 
-  public async selectByRoomId(roomId: string): Promise<User[]> {
-    const pgClient = await this.pgPool.client()
-
+  public async selectByRoomId(
+    roomId: string,
+    pgClient: PoolClient,
+  ): Promise<User[]> {
     const query =
       "SELECT u.id, u.is_admin, u.is_system, u.room_id, u.icon_id, ts.topic_id FROM users u LEFT JOIN topics_speakers ts on u.id = ts.user_id WHERE u.room_id = $1 AND u.has_left = false"
     try {
@@ -86,11 +88,8 @@ class UserRepository implements IUserRepository {
 
       return users
     } catch (e) {
-      console.log(e)
       UserRepository.logError(e, "selectByRoomId()")
       throw e
-    } finally {
-      pgClient.release()
     }
   }
 

--- a/app/server/src/infra/repository/admin/AdminRepository.ts
+++ b/app/server/src/infra/repository/admin/AdminRepository.ts
@@ -1,6 +1,7 @@
 import IAdminRepository from "../../../domain/admin/IAdminRepository"
 import Admin from "../../../domain/admin/admin"
 import PGPool from "../PGPool"
+import { PoolClient } from "pg"
 
 class AdminRepository implements IAdminRepository {
   constructor(private readonly pgPool: PGPool) {}
@@ -47,9 +48,10 @@ class AdminRepository implements IAdminRepository {
     }
   }
 
-  public async selectIdsByRoomId(roomId: string): Promise<string[]> {
-    const pgClient = await this.pgPool.client()
-
+  public async selectIdsByRoomId(
+    roomId: string,
+    pgClient: PoolClient,
+  ): Promise<string[]> {
     const query = "SELECT admin_id FROM rooms_admins WHERE room_id = $1"
 
     try {
@@ -58,8 +60,6 @@ class AdminRepository implements IAdminRepository {
     } catch (e) {
       AdminRepository.logError(e, "find()")
       throw e
-    } finally {
-      pgClient.release()
     }
   }
 

--- a/app/server/src/infra/repository/admin/AdminRepository.ts
+++ b/app/server/src/infra/repository/admin/AdminRepository.ts
@@ -63,6 +63,25 @@ class AdminRepository implements IAdminRepository {
     }
   }
 
+  public async selectIdsByRoomIds(
+    roomIds: string[],
+    pgClient: PoolClient,
+  ): Promise<Record<string, string[]>> {
+    const query =
+      "SELECT room_id, admin_id FROM rooms_admins WHERE room_id = ANY($1::UUID[])"
+
+    const res = await pgClient.query(query, [roomIds])
+    return res.rows.reduce<Record<string, string[]>>((acc, cur) => {
+      if (cur.room_id in acc) {
+        acc[cur.room_id].push(cur.admin_id)
+      } else {
+        acc[cur.room_id] = [cur.acmin_id]
+      }
+
+      return acc
+    }, {})
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private static logError(error: any, context: string) {
     const datetime = new Date().toISOString()

--- a/app/server/src/infra/repository/admin/EphemeralAdminRepository.ts
+++ b/app/server/src/infra/repository/admin/EphemeralAdminRepository.ts
@@ -23,6 +23,19 @@ class EphemeralAdminRepository implements IAdminRepository {
       this.admins.filter((a) => roomId in a.managedRoomsIds).map((a) => a.id),
     )
   }
+
+  public selectIdsByRoomIds(
+    roomIds: string[],
+  ): Promise<Record<string, string[]>> {
+    return Promise.resolve(
+      roomIds.reduce<Record<string, string[]>>((acc, cur) => {
+        acc[cur] = this.admins
+          .filter((a) => a.managedRoomsIds.includes(cur))
+          .map((a) => a.id)
+        return acc
+      }, {}),
+    )
+  }
 }
 
 export default EphemeralAdminRepository

--- a/app/server/src/infra/repository/chatItem/ChatItemRepository.ts
+++ b/app/server/src/infra/repository/chatItem/ChatItemRepository.ts
@@ -219,7 +219,6 @@ class ChatItemRepository implements IChatItemRepository {
     }
   }
 
-  // NOTE: arrow functionにしないとthisの挙動のせいでバグる
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private static buildChatItem(row: any) {
     const id = row.id
@@ -309,7 +308,6 @@ class ChatItemRepository implements IChatItemRepository {
       }
     }
 
-    // NOTE: 複数回クエリを発行するとパフォーマンスの低下につながるので、一回のクエリでとってこれるならそうしたい
     switch (chatItemType) {
       case "message":
         return new Message(

--- a/app/server/src/infra/repository/chatItem/ChatItemRepository.ts
+++ b/app/server/src/infra/repository/chatItem/ChatItemRepository.ts
@@ -138,7 +138,7 @@ class ChatItemRepository implements IChatItemRepository {
       const res = await pgClient.query(query, [chatItemId])
       if (res.rowCount < 1) return null
 
-      return await this.buildChatItem(res.rows[0])
+      return await ChatItemRepository.buildChatItem(res.rows[0])
     } catch (e) {
       ChatItemRepository.logError(e, "find()")
       throw e
@@ -151,25 +151,53 @@ class ChatItemRepository implements IChatItemRepository {
     roomId: string,
     pgClient: PoolClient,
   ): Promise<ChatItem[]> {
-    const query =
-      "SELECT " +
-      "ci.id, ci.room_id, ci.topic_id, ci.user_id, ci.chat_item_type_id, ci.sender_type_id, ci.quote_id, ci.content, ci.timestamp, ci.created_at, " +
-      "u.icon_id, u.is_admin, u.is_system, u.has_left, " +
-      "q.id AS quote_id, q.room_id AS quote_room_id, q.topic_id AS quote_topic_id, q.user_id AS quote_user_id, q.chat_item_type_id AS quote_type_id, q.sender_type_id AS quote_sender_type_id, q.content AS quote_content, q.timestamp AS quote_timestamp, q.created_at AS quote_created_at, " +
-      "qu.icon_id AS quote_icon_id, qu.is_admin AS quote_is_admin, qu.is_system AS quote_is_system, qu.has_left AS quote_has_left " +
-      "FROM chat_items ci " +
-      "JOIN users u ON ci.user_id = u.id AND ci.room_id = $1 " +
-      "LEFT JOIN chat_items q ON ci.quote_id = q.id " +
-      "LEFT JOIN users qu ON q.user_id = qu.id " +
-      "ORDER BY ci.created_at"
+    const query = `SELECT
+        ci.id, ci.room_id, ci.topic_id, ci.user_id, ci.chat_item_type_id, ci.sender_type_id, ci.quote_id, ci.content, ci.timestamp, ci.created_at,
+        u.icon_id, u.is_admin, u.is_system, u.has_left,
+        q.id AS quote_id, q.room_id AS quote_room_id, q.topic_id AS quote_topic_id, q.user_id AS quote_user_id, q.chat_item_type_id AS quote_type_id, q.sender_type_id AS quote_sender_type_id, q.content AS quote_content, q.timestamp AS quote_timestamp, q.created_at AS quote_created_at,
+        qu.icon_id AS quote_icon_id, qu.is_admin AS quote_is_admin, qu.is_system AS quote_is_system, qu.has_left AS quote_has_left
+        FROM chat_items ci
+        JOIN users u ON ci.user_id = u.id AND ci.room_id = $1
+        LEFT JOIN chat_items q ON ci.quote_id = q.id
+        LEFT JOIN users qu ON q.user_id = qu.id
+        ORDER BY ci.created_at`
 
     try {
       const res = await pgClient.query(query, [roomId])
-      return Promise.all(res.rows.map(this.buildChatItem))
+      return Promise.all(res.rows.map(ChatItemRepository.buildChatItem))
     } catch (e) {
       ChatItemRepository.logError(e, "selectByRoomId()")
       throw e
     }
+  }
+
+  public async selectByRoomIds(
+    roomIds: string[],
+    pgClient: PoolClient,
+  ): Promise<Record<string, ChatItem[]>> {
+    const query = `SELECT
+        ci.id, ci.room_id, ci.topic_id, ci.user_id, ci.chat_item_type_id, ci.sender_type_id, ci.quote_id, ci.content, ci.timestamp, ci.created_at,
+        u.icon_id, u.is_admin, u.is_system, u.has_left,
+        q.id AS quote_id, q.room_id AS quote_room_id, q.topic_id AS quote_topic_id, q.user_id AS quote_user_id, q.chat_item_type_id AS quote_type_id, q.sender_type_id AS quote_sender_type_id, q.content AS quote_content, q.timestamp AS quote_timestamp, q.created_at AS quote_created_at,
+        qu.icon_id AS quote_icon_id, qu.is_admin AS quote_is_admin, qu.is_system AS quote_is_system, qu.has_left AS quote_has_left
+        FROM chat_items ci
+        JOIN users u ON ci.user_id = u.id AND ci.room_id = ANY($1::UUID[])
+        LEFT JOIN chat_items q ON ci.quote_id = q.id
+        LEFT JOIN users qu ON q.user_id = qu.id
+        ORDER BY ci.created_at`
+
+    const res = await pgClient.query(query, [roomIds])
+    return res.rows.reduce<Record<string, ChatItem[]>>((acc, cur) => {
+      const chatItem = ChatItemRepository.buildChatItem(cur)
+
+      if (cur.room_id in acc) {
+        acc[cur.room_id].push(chatItem)
+      } else {
+        acc[cur.room_id] = [chatItem]
+      }
+
+      return acc
+    }, {})
   }
 
   public async pinChatItem(chatItem: ChatItem) {
@@ -193,7 +221,7 @@ class ChatItemRepository implements IChatItemRepository {
 
   // NOTE: arrow functionにしないとthisの挙動のせいでバグる
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private buildChatItem(row: any) {
+  private static buildChatItem(row: any) {
     const id = row.id
     const roomId = row.room_id
     const topicId = row.topic_id

--- a/app/server/src/infra/repository/chatItem/ChatItemRepository.ts
+++ b/app/server/src/infra/repository/chatItem/ChatItemRepository.ts
@@ -7,6 +7,7 @@ import ChatItem from "../../../domain/chatItem/ChatItem"
 import PGPool from "../PGPool"
 import { ChatItemSenderType, ChatItemType } from "sushi-chat-shared"
 import User from "../../../domain/user/User"
+import { PoolClient } from "pg"
 
 class ChatItemRepository implements IChatItemRepository {
   constructor(private readonly pgPool: PGPool) {}
@@ -146,9 +147,10 @@ class ChatItemRepository implements IChatItemRepository {
     }
   }
 
-  public async selectByRoomId(roomId: string): Promise<ChatItem[]> {
-    const pgClient = await this.pgPool.client()
-
+  public async selectByRoomId(
+    roomId: string,
+    pgClient: PoolClient,
+  ): Promise<ChatItem[]> {
     const query =
       "SELECT " +
       "ci.id, ci.room_id, ci.topic_id, ci.user_id, ci.chat_item_type_id, ci.sender_type_id, ci.quote_id, ci.content, ci.timestamp, ci.created_at, " +
@@ -167,8 +169,6 @@ class ChatItemRepository implements IChatItemRepository {
     } catch (e) {
       ChatItemRepository.logError(e, "selectByRoomId()")
       throw e
-    } finally {
-      pgClient.release()
     }
   }
 

--- a/app/server/src/infra/repository/chatItem/EphemeralChatItemRepository.ts
+++ b/app/server/src/infra/repository/chatItem/EphemeralChatItemRepository.ts
@@ -36,6 +36,17 @@ class EphemeralChatItemRepository implements IChatItemRepository {
     )
   }
 
+  public selectByRoomIds(
+    roomIds: string[],
+  ): Promise<Record<string, ChatItem[]>> {
+    return Promise.resolve(
+      roomIds.reduce<Record<string, ChatItem[]>>((acc, cur) => {
+        acc[cur] = this.chatItems.filter((c) => c.user.roomId === cur)
+        return acc
+      }, {}),
+    )
+  }
+
   public pinChatItem(chatItem: ChatItem) {
     this.chatItems = this.chatItems.filter((c) => c.id !== chatItem.id)
 

--- a/app/server/src/infra/repository/room/EphemeralRoomRepository.ts
+++ b/app/server/src/infra/repository/room/EphemeralRoomRepository.ts
@@ -25,8 +25,12 @@ class EphemeralRoomRepository implements IRoomRepository {
     )
   }
 
-  public async find(roomId: string) {
+  public find(roomId: string) {
     return Promise.resolve(this.rooms.find((r) => r.id === roomId) ?? null)
+  }
+
+  public findRooms(roomIds: string[]) {
+    return Promise.resolve(this.rooms.filter((r) => roomIds.includes(r.id)))
   }
 
   public update(room: RoomClass) {

--- a/app/server/src/infra/repository/room/RoomRepository.ts
+++ b/app/server/src/infra/repository/room/RoomRepository.ts
@@ -86,21 +86,23 @@ class RoomRepository implements IRoomRepository {
   public async find(roomId: string): Promise<RoomClass | null> {
     const pgClient = await this.pgPool.client()
 
-    const roomQuery =
-      "SELECT r.title, r.room_state_id, r.invite_key, r.description, r.start_at, r.finish_at, r.archived_at, u.id as system_user_id  " +
-      "FROM rooms r JOIN users u on u.is_system = true AND r.id = u.room_id  WHERE r.id = $1"
-    const topicsQuery =
-      "WITH topic as (" +
-      "SELECT t.id, t.topic_state_id, t.title, t.offset_mil_sec, toa.opened_at_mil_sec, tpa.paused_at_mil_sec " +
-      "FROM topics t " +
-      "LEFT OUTER JOIN topic_opened_at toa on t.id = toa.topic_id AND t.room_id = toa.room_id " +
-      "LEFT OUTER JOIN topic_paused_at tpa on t.id = tpa.topic_id AND t.room_id = tpa.room_id " +
-      "WHERE t.room_id = $1" +
-      ")" +
-      "SELECT topic.id, topic.topic_state_id, topic.title, topic.offset_mil_sec, topic.opened_at_mil_sec, topic.paused_at_mil_sec, (" +
-      "SELECT chat_item_id FROM topics_pinned_chat_items WHERE room_id = $1 AND topic_id = topic.id ORDER BY created_at DESC LIMIT 1" +
-      ") as pinned_chat_item_id " +
-      "FROM topic ORDER BY topic.id"
+    const roomQuery = `SELECT r.title, r.room_state_id, r.invite_key, r.description, r.start_at, r.finish_at, r.archived_at, u.id as system_user_id
+      FROM rooms r JOIN users u on u.is_system = true AND r.id = u.room_id WHERE r.id = $1`
+
+    const topicsQuery = `WITH topic as (
+        SELECT t.id, t.topic_state_id, t.title, t.offset_mil_sec, toa.opened_at_mil_sec, tpa.paused_at_mil_sec FROM topics t
+        LEFT OUTER JOIN topic_opened_at toa on t.id = toa.topic_id AND t.room_id = toa.room_id
+        LEFT OUTER JOIN topic_paused_at tpa on t.id = tpa.topic_id AND t.room_id = tpa.room_id
+        WHERE t.room_id = $1
+      )
+      SELECT topic.id, topic.topic_state_id, topic.title, topic.offset_mil_sec, topic.opened_at_mil_sec, topic.paused_at_mil_sec,
+      (
+      SELECT chat_item_id FROM topics_pinned_chat_items
+      WHERE room_id = $1 AND topic_id = topic.id
+      ORDER BY created_at DESC
+      LIMIT 1
+      ) as pinned_chat_item_id
+      FROM topic ORDER BY topic.id`
 
     try {
       const [roomRes, topicsRes, adminIds, users, stamps, chatItems] =

--- a/app/server/src/infra/repository/room/RoomRepository.ts
+++ b/app/server/src/infra/repository/room/RoomRepository.ts
@@ -107,10 +107,10 @@ class RoomRepository implements IRoomRepository {
         await Promise.all([
           pgClient.query(roomQuery, [roomId]),
           pgClient.query(topicsQuery, [roomId]),
-          this.adminRepository.selectIdsByRoomId(roomId),
-          this.userRepository.selectByRoomId(roomId),
-          this.stampRepository.selectByRoomId(roomId),
-          this.chatItemRepository.selectByRoomId(roomId),
+          this.adminRepository.selectIdsByRoomId(roomId, pgClient),
+          this.userRepository.selectByRoomId(roomId, pgClient),
+          this.stampRepository.selectByRoomId(roomId, pgClient),
+          this.chatItemRepository.selectByRoomId(roomId, pgClient),
         ])
 
       if (roomRes.rowCount < 1) return null

--- a/app/server/src/infra/repository/stamp/EphemeralStampRepository.ts
+++ b/app/server/src/infra/repository/stamp/EphemeralStampRepository.ts
@@ -29,6 +29,15 @@ class EphemeralStampRepository implements IStampRepository {
   public selectByRoomId(roomId: string): Promise<Stamp[]> {
     return Promise.resolve(this.stamps.filter((s) => s.roomId === roomId))
   }
+
+  public selectByRoomIds(roomIds: string[]): Promise<Record<string, Stamp[]>> {
+    return Promise.resolve(
+      roomIds.reduce<Record<string, Stamp[]>>((acc, cur) => {
+        acc[cur] = this.stamps.filter((s) => s.roomId === cur)
+        return acc
+      }, {}),
+    )
+  }
 }
 
 export default EphemeralStampRepository

--- a/app/server/src/infra/repository/stamp/StampRepository.ts
+++ b/app/server/src/infra/repository/stamp/StampRepository.ts
@@ -82,6 +82,34 @@ class StampRepository implements IStampRepository {
     }
   }
 
+  public async selectByRoomIds(
+    roomIds: string[],
+    pgClient: PoolClient,
+  ): Promise<Record<string, Stamp[]>> {
+    const query =
+      "SELECT room_id, id, topic_id, user_id, created_at, timestamp FROM stamps WHERE room_id = ANY($1::UUID[])"
+
+    const res = await pgClient.query(query, [roomIds])
+    return res.rows.reduce<Record<string, Stamp[]>>((acc, cur) => {
+      const stamp = new Stamp(
+        cur.id,
+        cur.user_id,
+        cur.room_id,
+        cur.topic_id,
+        cur.created_at,
+        cur.timestamp,
+      )
+
+      if (cur.room_id in acc) {
+        acc[cur.room_id].push(stamp)
+      } else {
+        acc[cur.room_id] = [stamp]
+      }
+
+      return acc
+    }, {})
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private static logError(error: any, context: string) {
     const datetime = new Date().toISOString()

--- a/app/server/src/infra/repository/stamp/StampRepository.ts
+++ b/app/server/src/infra/repository/stamp/StampRepository.ts
@@ -1,6 +1,7 @@
 import IStampRepository from "../../../domain/stamp/IStampRepository"
 import Stamp from "../../../domain/stamp/Stamp"
 import PGPool from "../PGPool"
+import { Pool, PoolClient } from "pg"
 
 class StampRepository implements IStampRepository {
   constructor(private readonly pgPool: PGPool) {}
@@ -57,9 +58,10 @@ class StampRepository implements IStampRepository {
     }
   }
 
-  public async selectByRoomId(roomId: string): Promise<Stamp[]> {
-    const pgClient = await this.pgPool.client()
-
+  public async selectByRoomId(
+    roomId: string,
+    pgClient: PoolClient,
+  ): Promise<Stamp[]> {
     const query =
       "SELECT id, topic_id, user_id, created_at, timestamp FROM stamps WHERE room_id = $1"
     try {
@@ -77,8 +79,6 @@ class StampRepository implements IStampRepository {
     } catch (e) {
       StampRepository.logError(e, "selectByRoomId()")
       throw e
-    } finally {
-      pgClient.release()
     }
   }
 

--- a/app/server/src/service/admin/AdminService.ts
+++ b/app/server/src/service/admin/AdminService.ts
@@ -30,33 +30,17 @@ class AdminService {
   public async getManagedRooms(
     command: getManagedRoomsCommand,
   ): Promise<RoomClass[]> {
-    const admin = await this.find(command.adminId)
-    const managedRoomsIds = admin.managedRoomsIds
-
-    // roomがnullの場合は無視する
-    const managedRooms = (
-      await Promise.all<RoomClass | null>(
-        managedRoomsIds.map(async (roomId) => {
-          const room = await this.findRoom(roomId)
-          return room
-        }),
-      )
-    ).filter((room): room is RoomClass => room != null)
-
-    return managedRooms
-  }
-
-  private async find(adminId: string): Promise<Admin> {
-    const admin = await this.adminRepository.find(adminId)
+    const admin = await this.adminRepository.find(command.adminId)
     if (!admin) {
       throw new Error(`[sushi-chat-server] Admin does not exists.`)
     }
-    return admin
-  }
 
-  private async findRoom(roomId: string): Promise<RoomClass | null> {
-    const room = await this.roomRepository.find(roomId)
-    return room
+    // roomがnullの場合は無視する
+    return (
+      await Promise.all(
+        admin.managedRoomsIds.map((id) => this.roomRepository.find(id)),
+      )
+    ).filter((room): room is RoomClass => room != null)
   }
 }
 

--- a/app/server/src/service/admin/AdminService.ts
+++ b/app/server/src/service/admin/AdminService.ts
@@ -35,12 +35,7 @@ class AdminService {
       throw new Error(`[sushi-chat-server] Admin does not exists.`)
     }
 
-    // roomがnullの場合は無視する
-    return (
-      await Promise.all(
-        admin.managedRoomsIds.map((id) => this.roomRepository.find(id)),
-      )
-    ).filter((room): room is RoomClass => room != null)
+    return this.roomRepository.findRooms(admin.managedRoomsIds)
   }
 }
 

--- a/app/server/src/service/admin/AdminService.ts
+++ b/app/server/src/service/admin/AdminService.ts
@@ -32,15 +32,11 @@ class AdminService {
   ): Promise<RoomClass[]> {
     const admin = await this.find(command.adminId)
     const managedRoomsIds = admin.managedRoomsIds
-    // FIXME: postgresqlのコネクションプールのリミットが10なので、for文でfindRoomを回しすぎるとプールが足りなくなって運
-    //        が悪いとデッドロックになるため、取得するルーム数を制限している。1リクエストにつき1コネクションを割り当てれ
-    //        ば直せそう。
-    const limitedManagedRoomIds = managedRoomsIds.slice(0,3)
 
     // roomがnullの場合は無視する
     const managedRooms = (
       await Promise.all<RoomClass | null>(
-        limitedManagedRoomIds.map(async (roomId) => {
+        managedRoomsIds.map(async (roomId) => {
           const room = await this.findRoom(roomId)
           return room
         }),

--- a/app/server/src/utils/delay.ts
+++ b/app/server/src/utils/delay.ts
@@ -1,10 +1,10 @@
 /**
  * [second]秒間待つための関数
  *
- * @param second 待ち時間
+ * @param ms 待ち時間[millisecond]
  * @returns
  */
-const delay = async (second: number) =>
-  new Promise((resolve) => setTimeout(resolve, second))
+const delay = async (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms))
 
 export default delay


### PR DESCRIPTION
close #672 

## やったこと
- 管理しているルーム一覧を撮るときにN+1になっていたのを修正
- リポジトリの中でDBのコネクションをパスして、同一の処理の中でDBのコネクションを複数確保しないようにした。
  - インターフェースに実装の詳細が染み出してるクソ実装だけど、スピード優先で妥協している

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
