### PR TITLE
urlを開く以前のスタンプ数を持たせる 

### DIFF
--- a/app/front/pages/room/_id.vue
+++ b/app/front/pages/room/_id.vue
@@ -307,6 +307,7 @@ export default Vue.extend({
           status: "success",
         })),
       )
+      StampStore.setStamps(res.data.stamps)
       res.data.topicStates.forEach((topicState) => {
         TopicStateItemStore.change({
           key: topicState.topicId,

--- a/app/front/store/stamps.ts
+++ b/app/front/store/stamps.ts
@@ -18,6 +18,11 @@ export default class Stamps extends VuexModule {
   }
 
   @Mutation
+  public setStamps(stamps: StampModel[]) {
+    this._stamps = stamps
+  }
+
+  @Mutation
   public add(s: StampModel) {
     this._stamps.push(s)
   }


### PR DESCRIPTION
close #590

#681 をバグらせてしまったので再提出

## やったこと
入室時に取得できるスタンプの履歴をストアに入れる
<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
別にAPI変更せんでよくね？って思ってます、問題あったら教えてください