### PR TITLE
ルーム終了後に投稿などの操作ができないように変更

### DIFF
--- a/app/front/assets/scss/index.scss
+++ b/app/front/assets/scss/index.scss
@@ -684,6 +684,8 @@
     .comment-footer {
       display: flex;
       align-items: flex-end;
+      min-height: 1.5rem;
+
       & > .comment-timestamp {
         color: $text-gray;
         font-size: 10px;

--- a/app/front/components/ChatRoom.vue
+++ b/app/front/components/ChatRoom.vue
@@ -4,6 +4,7 @@
       :title="topic.title"
       :topic-index="topicId"
       :pinned-chat-item="pinnedChatItem"
+      :disable-interaction="disableInteraction"
       @download="clickDownload"
       @click-show-all="clickShowAll"
       @click-not-show-all="clickNotShowAll"
@@ -29,6 +30,7 @@
               "
               :topic-id="topicId"
               :message="message"
+              :disable-interaction="disableInteraction"
               @click-thumb-up="clickReaction"
               @click-reply="selectChatItem(message)"
               @click-pin="pinChatItem(message.id)"
@@ -70,6 +72,7 @@
       </button>
     </div>
     <TextArea
+      v-show="!disableInteraction"
       :topic-title="topic.title"
       :topic-id="topicId"
       :disabled="topicState == 'not-started'"
@@ -127,6 +130,10 @@ export default Vue.extend({
       type: String,
       default: "not-started",
     } as PropOptions<TopicState>,
+    disableInteraction: {
+      type: Boolean,
+      required: true,
+    },
   },
   data(): DataType {
     return {

--- a/app/front/components/Message.vue
+++ b/app/front/components/Message.vue
@@ -59,7 +59,7 @@
               : showTimestamp(message.timestamp)
           }}
         </div>
-        <div class="badges">
+        <div v-show="!disableInteraction" class="badges">
           <template v-if="message.status !== 'failure'">
             <button
               v-if="isAdminorSpeaker"
@@ -195,6 +195,10 @@ export default Vue.extend({
     } as PropOptions<ChatItemWithStatus>,
     topicId: {
       type: Number,
+      required: true,
+    },
+    disableInteraction: {
+      type: Boolean,
       required: true,
     },
   },

--- a/app/front/components/TopicHeader.vue
+++ b/app/front/components/TopicHeader.vue
@@ -60,7 +60,7 @@
         </span>
       </button>
       <button
-        v-show="isAdmin || isSpeaker"
+        v-show="(isAdmin || isSpeaker) && !disableInteraction"
         aria-label="ピン留め解除"
         title="ピン留め解除"
         @click="removePinnedMessage"
@@ -107,6 +107,10 @@ export default Vue.extend({
       type: Object,
       default: undefined,
     } as PropOptions<ChatItemModel | undefined>,
+    disableInteraction: {
+      type: Boolean,
+      required: true,
+    },
   },
   data(): DataType {
     return {

--- a/app/front/pages/room/_id.vue
+++ b/app/front/pages/room/_id.vue
@@ -37,6 +37,7 @@
             :topic-index="index"
             :topic-id="topic.id"
             :topic-state="topicStateItems[topic.id]"
+            :disable-interaction="room.state === 'finished'"
           />
         </div>
       </div>


### PR DESCRIPTION
close #661 

## やったこと
- ルーム終了後
  - 吹き出し下部の、ピン留め・リプライ・リアクションボタンを非表示に
  - 入力欄を非表示に
  - ヘッダー内のピン留めを解除するボタンを非表示に


<!--
## やっていないこと
-->


## スクリーンショット
<img width="674" alt="image" src="https://user-images.githubusercontent.com/38308823/156781123-e6a5ae9a-71a4-4f8e-b7cd-11c7db207515.png">


<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
