### PR TITLE
ローディング遷移時に遷移前のページを表示しない

### DIFF
--- a/app/front/nuxt.config.js
+++ b/app/front/nuxt.config.js
@@ -56,10 +56,7 @@ export default {
   css: ["@/assets/scss/app.scss"],
 
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
-  plugins: [
-    '@/plugins/apiClient',
-    '@/plugins/socket',
-  ],
+  plugins: ["@/plugins/apiClient", "@/plugins/socket"],
 
   // Auto import components: https://go.nuxtjs.dev/config-components
   components: true,
@@ -78,9 +75,9 @@ export default {
       "@nuxtjs/pwa",
       {
         manifest: {
-          lang: 'ja',
+          lang: "ja",
         },
-      }
+      },
     ],
   ],
   loaders: {
@@ -91,7 +88,11 @@ export default {
       silent: true,
     },
   },
-
+  loadingIndicator: {
+    name: "circle",
+    color: "#f28d2f",
+    background: "white",
+  },
   // Modules: https://go.nuxtjs.dev/config-modules
   modules: [
     // https://go.nuxtjs.dev/axios
@@ -99,26 +100,26 @@ export default {
     "nuxt-webfontloader",
     "socket.io-client",
     [
-      '@nuxtjs/firebase',
+      "@nuxtjs/firebase",
       {
         config: {
-          apiKey: 'AIzaSyCBQ3FB9HwLD0m1tn9UvbOHyovydVxffLE',
-          authDomain: 'sushi-chat-osushi.firebaseapp.com',
-          projectId: 'sushi-chat-osushi',
-          storageBucket: 'sushi-chat-osushi.appspot.com',
-          messagingSenderId: '803145893857',
-          appId: '1:803145893857:web:762dc197f836b4fcfb34a0',
-          measurementId: 'G-3L8Q6J93EC'
+          apiKey: "AIzaSyCBQ3FB9HwLD0m1tn9UvbOHyovydVxffLE",
+          authDomain: "sushi-chat-osushi.firebaseapp.com",
+          projectId: "sushi-chat-osushi",
+          storageBucket: "sushi-chat-osushi.appspot.com",
+          messagingSenderId: "803145893857",
+          appId: "1:803145893857:web:762dc197f836b4fcfb34a0",
+          measurementId: "G-3L8Q6J93EC",
         },
         services: {
           auth: {
             initialize: {
-              onIdTokenChangedAction: 'auth/onIdTokenChangedAction',
+              onIdTokenChangedAction: "auth/onIdTokenChangedAction",
             },
-          }
-        }
-      }
-    ]
+          },
+        },
+      },
+    ],
   ],
 
   // Axios module configuration: https://go.nuxtjs.dev/config-axios
@@ -133,7 +134,9 @@ export default {
   webfontloader: {
     google: {
       // FIXME: デグレが起きて旧バージョンを見たいケースのためにコメントアウトにしておく。不要になったら消す。
-      families: ["M PLUS 1p:100,400,700", /* "Material Icons", "Material Icons Outlined" */],
+      families: [
+        "M PLUS 1p:100,400,700" /* "Material Icons", "Material Icons Outlined" */,
+      ],
     },
   },
 

--- a/app/front/pages/index.vue
+++ b/app/front/pages/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="lp">
+  <div v-show="loadingFinished" class="lp">
     <header class="lp__header">
       <div class="lp__header--title">
         <img :src="require('@/static/icon.png')" />sushi-chat
@@ -42,23 +42,24 @@
 <script lang="ts">
 import Vue from "vue"
 import { AuthStore } from "~/store"
+
+type DataType = {
+  loadingFinished: boolean
+}
+
 export default Vue.extend({
   name: "Index",
-  computed: {
-    isLoggedIn() {
-      return AuthStore.isLoggedIn
-    },
+  data(): DataType {
+    return {
+      loadingFinished: false,
+    }
   },
-  watch: {
-    isLoggedIn: {
-      immediate: true,
-      handler() {
-        if (this.isLoggedIn) {
-          // NOTE: ログイン済みの場合はプロフィールページへリダイレクトする
-          this.$router.push("/home")
-        }
-      },
-    },
+  created() {
+    if (AuthStore.isLoggedIn) {
+      this.$router.push("/home")
+      return
+    }
+    this.loadingFinished = true
   },
   methods: {
     async signInWithGoogle() {

--- a/app/front/pages/room/_id.vue
+++ b/app/front/pages/room/_id.vue
@@ -171,6 +171,7 @@ export default Vue.extend({
         }
       } else if (this.room.state === "finished") {
         // 終了時。すべてのトピックが閉じたルームのアーカイブが閲覧できる。
+        this.isRoomEnter = true
         const history = await this.$apiClient
           .get({
             pathname: "/room/:id/history",
@@ -195,7 +196,6 @@ export default Vue.extend({
             PinnedChatItemsStore.add(pinnedChatItem)
           }
         })
-        this.isRoomEnter = true
       }
     },
     // socket.ioのセットアップ。配信を受け取る


### PR DESCRIPTION
close #xxx

## やったこと
- 終了後のルームで一瞬寿司選択画面が表示されていたのでされないようにした
- ログイン状態で/indexに遷移した際一瞬画面が表示されていたのをされないようにした(これで対応として合っているのだろうか)

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
