### PR TITLE
エラーハンドリングを追加

### DIFF
--- a/app/front/pages/invited.vue
+++ b/app/front/pages/invited.vue
@@ -39,29 +39,42 @@ export default Vue.extend({
     InviteSuccess,
   },
   async asyncData({ app, query }) {
-    const res = await app.$apiClient.get({
-      pathname: "/room/:id",
-      params: { id: query.roomId as string },
-    })
+    if (
+      query.roomId == null ||
+      query.roomId === "" ||
+      query.adminInviteKey == null ||
+      query.adminInviteKey === ""
+    ) {
+      throw new Error(
+        "エラーが発生しました。URLが間違っている可能性があります。",
+      )
+    }
+
+    const res = await app.$apiClient
+      .get({
+        pathname: "/room/:id",
+        params: { id: query.roomId as string },
+      })
+      .catch(() => {
+        throw new Error(
+          "エラーが発生しました。URLが間違っている可能性があります。",
+        )
+      })
     if (res.result === "error") {
-      throw new Error("ルーム情報なし")
+      throw res.error
     }
     return { room: res.data }
   },
   data(): DataType {
     return { room: {} as RoomModel, roomId: "", adminInviteKey: "" }
   },
-  created() {
+  mounted() {
     // roomId取得
     this.roomId = this.$route.query.roomId as string
     // adminInviteKey取得
     this.adminInviteKey = this.$route.query.admin_invite_key as string
-  },
-  mounted() {
-    // roomId取得
-    this.roomId = this.$route.query.roomId as string
-    if (this.roomId !== "") {
-      // TODO: this.room.idが存在しない→404
+    if (this.roomId == null || this.roomId === "") {
+      this.$router.push("/")
     }
   },
   methods: {

--- a/app/front/pages/room/_id.vue
+++ b/app/front/pages/room/_id.vue
@@ -129,7 +129,7 @@ export default Vue.extend({
     }
   },
   mounted() {
-    if (typeof this.room.id === "undefined") {
+    if (typeof this.room.id === "undefined" || this.room.id === "") {
       this.$router.push("/")
     }
     // statusに合わせた操作をする

--- a/app/front/pages/room/_id.vue
+++ b/app/front/pages/room/_id.vue
@@ -149,6 +149,9 @@ export default Vue.extend({
           params: { id: this.room.id },
         })
         .catch((e) => {
+          window.alert(
+            "エラーが発生しました。URLが間違っている可能性があります。",
+          )
           throw new Error(e)
         })
 

--- a/app/front/store/stamps.ts
+++ b/app/front/store/stamps.ts
@@ -45,11 +45,10 @@ export default class Stamps extends VuexModule {
   public async sendFavorite(topicId: number) {
     const socket = await buildSocket(UserItemStore.userItems.isAdmin)
     const id = getUUID()
-    // StampStoreは配信で追加する
     this.add({
       id,
       topicId,
-      timestamp: 1000, // TODO: 正しいタイムスタンプを設定する
+      timestamp: 0,
       createdAt: new Date().toISOString(),
     })
     await emitAsync(socket, "POST_STAMP", { topicId, id })


### PR DESCRIPTION
close #xxx

## やったこと

- `/room/_id` で`_id`が指定されていない場合に、window.alertの後、`/home`へリダイレクトさせた
- `/invited?roomId=xxx&adminInviteKey=yyy`で、roomIdが指定されていない、roomIdが間違っている、adminInviteKeyが間違っているの3パターンについて日本語のエラーメッセージを表示
- コメント等の削除

<!--
## やっていないこと
-->

<!--
## スクリーンショット
-->

<!--
## 動作確認手順
-->

<!--
## 困っていること
-->

<!--
## 既知のバグ（別PRで対応するものなど）
-->

## 参考リンク・補足など
